### PR TITLE
Make setup.py include assets in package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ from setuptools import setup
 setup(
     name="ttkwidgets",
     packages=["ttkwidgets"],
+    py_modules=["ttkwidgets"],
+    package_data={"ttkwidgets": ["assets/*"]},
     version="0.5.0",
     description=" A collection of widgets for Tkinter's ttk extensions by various authors ",
     author="RedFantom and others",
@@ -17,3 +19,4 @@ setup(
     include_package_data=True,
     install_requires=["pillow"]
 )
+


### PR DESCRIPTION
I had installed ttkwidgets with `python setup.py install` (in archlinux) and when I tried to use it, I realized that the `assets/` folder had not been included in the package. So I have changed the `setup.py` file to fix this issue.