### PR TITLE
Merge snaptoplevel into master to add SnapToplevel widget

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,11 +1,20 @@
+codecov:
+  branch: master
+
 coverage:
-  ci:
-    - travis
-    - appveyor
+  range: 50...100
+
   status:
-    patch: false
-    changes: false
     project:
-      default:
-        target: '80'
-comment: false
+      enabled: yes
+      target: 80%
+    patch:
+      enabled: yes
+      target: 80%
+      if_no_uploads: error
+      if_not_found: success
+    changes: false
+
+comment:
+  layout: "header, diff"
+behavior: default

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,6 +8,7 @@ This file contains a list of all the authors of widgets in this repository.
   * `ScrolledListbox`
   * `FontChooser`, based on an idea by [Nelson Brochado](https://www.github.com/nbro)
   * `FontSelectFrame`
+  * `SnapToplevel`
 - The Python Team
   * `Calendar`, found [here](http://svn.python.org/projects/sandbox/trunk/ttk-gsoc/samples/ttkcalendar.py)
 - Mitja Martini

--- a/examples/example_snaptoplevel.py
+++ b/examples/example_snaptoplevel.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) RedFantom 2017
+# For license see LICENSE
+import tkinter as tk
+from ttkwidgets import SnapToplevel
+
+
+window = tk.Tk()
+top = SnapToplevel(window, location=tk.RIGHT, allow_change=True, locked=False)
+window.mainloop()

--- a/examples/example_snaptoplevel.py
+++ b/examples/example_snaptoplevel.py
@@ -7,5 +7,5 @@ from ttkwidgets import SnapToplevel
 
 
 window = tk.Tk()
-top = SnapToplevel(window, location=tk.RIGHT, allow_change=True, locked=False)
+top = SnapToplevel(window, anchor=tk.RIGHT, allow_change=True, locked=False)
 window.mainloop()

--- a/tests/test_snaptoplevel.py
+++ b/tests/test_snaptoplevel.py
@@ -117,5 +117,6 @@ class TestSnapToplevel(BaseWidgetTest):
 
     def test_snaptoplevel_set_geometry_self_allow_change(self):
         snap = SnapToplevel(self.window, allow_change=True)
+        snap._snapped = False
         self.window.update()
         snap.set_geometry_self()

--- a/tests/test_snaptoplevel.py
+++ b/tests/test_snaptoplevel.py
@@ -1,0 +1,103 @@
+# Copyright (c) RedFantom 2017
+# For license see LICENSE
+from ttkwidgets import SnapToplevel
+from tests import BaseWidgetTest
+try:
+    import Tkinter as tk
+except ImportError:
+    import tkinter as tk
+
+
+class TestSnapToplevel(BaseWidgetTest):
+    def test_snaptoplevel_init(self):
+        snap = SnapToplevel(self.window)
+
+    def test_snaptoplevel_kwargs(self):
+        snap = SnapToplevel(self.window, border=50, anchor=tk.LEFT, offset_sides=10, offset_top=30, allow_change=True,
+                            resizable=True)
+
+        def configure_function(event):
+            assert isinstance(event.widget, tk.Toplevel) or isinstance(event.widget, tk.Tk)
+
+        snap = SnapToplevel(self.window, configure_function=configure_function)
+        self.window.update()
+
+        snap.config(border=50, anchor=tk.LEFT, offset_sides=10, offset_top=30, allow_change=True, resizable=True)
+        self.assertEqual(snap.cget("border"), 50)
+        self.assertEqual(snap.cget("anchor"), tk.LEFT)
+        self.assertEqual(snap.cget("offset_sides"), 10)
+        self.assertEqual(snap.cget("offset_top"), 30)
+        self.assertEqual(snap.cget("allow_change"), True)
+        self.assertEqual(snap.cget("resizable"), True)
+
+    def test_snaptoplevel_kwargs_raise(self):
+        self.assertRaises(ValueError, lambda: SnapToplevel(tk.Label()))
+        self.assertRaises(ValueError, lambda: SnapToplevel(self.window, anchor=tk.W))
+        self.assertRaises(ValueError, lambda: SnapToplevel(self.window, border="50"))
+        self.assertRaises(ValueError, lambda: SnapToplevel(self.window, offset_sides="5"))
+        self.assertRaises(ValueError, lambda: SnapToplevel(self.window, offset_top="5"))
+        self.assertRaises(ValueError, lambda: SnapToplevel(self.window, allow_change="True"))
+        self.assertRaises(ValueError, lambda: SnapToplevel(self.window, resizable="False"))
+
+    def test_snaptoplevel_get_offset_values(self):
+        snap = SnapToplevel(self.window)
+        sides, top = snap.get_offset_values()
+        self.assertIsInstance(sides, int)
+        self.assertIsInstance(top, int)
+        self.assertGreaterEqual(sides, 0)
+        self.assertGreaterEqual(top, 0)
+
+    def test_snaptoplevel_get_new_geometry_master(self):
+        snap = SnapToplevel(self.window)
+        results = snap.get_new_geometry_master()
+        self.assertIsInstance(results, tuple)
+        self.assertEqual(len(results), 4)
+        for value in results:
+            self.assertIsInstance(value, int)
+            self.assertGreaterEqual(value, 0)
+
+    def test_snaptoplevel_set_geometry_master(self):
+        snap = SnapToplevel(self.window)
+        snap.set_geometry_master()
+
+    def test_snaptoplevel_get_points_sides_for_window(self):
+        self.window.update()
+        results = SnapToplevel.get_points_sides_for_window(self.window)
+        self.assertIsInstance(results, tuple)
+        self.assertEqual(len(results), 4)
+        for value in results:
+            self.assertIsInstance(value, tuple)
+            self.assertEqual(len(value), 2)
+            for number in value:
+                self.assertIsInstance(number, int)
+
+    def test_get_distance_between_points(self):
+        distance = SnapToplevel.get_distance_between_points((0, 0), (0, 0))
+        self.assertEqual(distance, 0)
+        distance = SnapToplevel.get_distance_between_points((0, 0), (0, 4))
+        self.assertEqual(distance, 4)
+
+    def test_snaptoplevel_changestate_callbacks(self):
+        snap = SnapToplevel(self.window)
+        self.window.update()
+        snap.minimize(None)
+        self.window.update()
+        snap.deminimize(None)
+        self.window.update()
+
+    def test_snaptoplevel_snap(self):
+        snap = SnapToplevel(self.window)
+        self.window.update()
+        snap._snap()
+
+    def test_snaptoplevel_get_distance_to_master(self):
+        results = SnapToplevel(self.window).get_distance_to_master()
+        self.assertIsInstance(results, dict)
+        self.assertEqual(len(results), 4)
+        self.assertTrue(tk.RIGHT in results)
+        self.assertTrue(tk.LEFT in results)
+        self.assertTrue(tk.TOP in results)
+        self.assertTrue(tk.BOTTOM in results)
+        for value in results.values():
+            self.assertIsInstance(value, int)
+            self.assertGreaterEqual(value, 0)

--- a/tests/test_snaptoplevel.py
+++ b/tests/test_snaptoplevel.py
@@ -22,13 +22,19 @@ class TestSnapToplevel(BaseWidgetTest):
         snap = SnapToplevel(self.window, configure_function=configure_function)
         self.window.update()
 
-        snap.config(border=50, anchor=tk.LEFT, offset_sides=10, offset_top=30, allow_change=True, resizable=True)
+        snap.configure(border=50)
+        snap.config(border=50, anchor=tk.LEFT, offset_sides=10, offset_top=30, allow_change=True, resizable=True,
+                    configure_function=None, locked=False, width=300)
+
         self.assertEqual(snap.cget("border"), 50)
         self.assertEqual(snap.cget("anchor"), tk.LEFT)
         self.assertEqual(snap.cget("offset_sides"), 10)
         self.assertEqual(snap.cget("offset_top"), 30)
         self.assertEqual(snap.cget("allow_change"), True)
         self.assertEqual(snap.cget("resizable"), True)
+        self.assertEqual(snap.cget("configure_function"), None)
+        self.assertEqual(snap.cget("locked"), False)
+        self.assertEqual(snap.cget("width"), 300)
 
     def test_snaptoplevel_kwargs_raise(self):
         self.assertRaises(ValueError, lambda: SnapToplevel(tk.Label()))
@@ -57,8 +63,10 @@ class TestSnapToplevel(BaseWidgetTest):
             self.assertGreaterEqual(value, 0)
 
     def test_snaptoplevel_set_geometry_master(self):
-        snap = SnapToplevel(self.window)
-        snap.set_geometry_master()
+        for anchor in (tk.RIGHT, tk.LEFT, tk.TOP, tk.BOTTOM):
+            window = tk.Toplevel()
+            snap = SnapToplevel(window, anchor=anchor)
+            snap.set_geometry_master()
 
     def test_snaptoplevel_get_points_sides_for_window(self):
         self.window.update()
@@ -101,3 +109,13 @@ class TestSnapToplevel(BaseWidgetTest):
         for value in results.values():
             self.assertIsInstance(value, int)
             self.assertGreaterEqual(value, 0)
+
+    def test_snaptoplevel_set_geometry_self_not_allow_change(self):
+        snap = SnapToplevel(self.window, allow_change=False)
+        self.window.update()
+        snap.set_geometry_self()
+
+    def test_snaptoplevel_set_geometry_self_allow_change(self):
+        snap = SnapToplevel(self.window, allow_change=True)
+        self.window.update()
+        snap.set_geometry_self()

--- a/ttkwidgets/__init__.py
+++ b/ttkwidgets/__init__.py
@@ -6,3 +6,4 @@ from ttkwidgets.scrolledlistbox import ScrolledListbox
 from ttkwidgets.debugwindow import DebugWindow
 from ttkwidgets.checkboxtreeview import CheckboxTreeview
 from ttkwidgets.itemscanvas import ItemsCanvas
+from ttkwidgets.snaptoplevel import SnapToplevel

--- a/ttkwidgets/snaptoplevel.py
+++ b/ttkwidgets/snaptoplevel.py
@@ -57,7 +57,7 @@ class SnapToplevel(tk.Toplevel):
         # It returns something like below if one was bound:
         # {"[55632584<lambda> %# %b %f %h %k %s %t %w %x %y %A %E %K %N %W %T %X %Y %D]" == "break"} break\n
         # This is probably because the implementation is not correct in the C bindings of Tkinter
-        if not self._configure_function and not master.bind("<Configure>") == "":
+        if not self._configure_function and master.bind("<Configure>") != "":
             raise ValueError("No original Configure binding provided while one was bound to the master Tk instance.")
 
         # Initialize Toplevel

--- a/ttkwidgets/snaptoplevel.py
+++ b/ttkwidgets/snaptoplevel.py
@@ -9,8 +9,7 @@ try:
 except ImportError:
     import tkinter as tk
     from tkinter import ttk
-
-# TODO: Allow the user to move the Toplevel to a different location on the window
+from math import sqrt, pow
 
 
 class SnapToplevel(tk.Toplevel):
@@ -38,10 +37,11 @@ class SnapToplevel(tk.Toplevel):
                        offset_sides       - Override default value
                        offset_top         - Override default value
                        allow_change       - Allow the changing of the Toplevel anchor by moving the window
+                       resizable          - Argument to self.resizable()
 
                        All other keyword arguments, such as width and height, are passed to the Toplevel
         """
-        # Process arguments
+        # Process given arguments
         if not isinstance(master, tk.Tk):
             raise ValueError("SnapWindows can only be created with a Tk instance as master.")
         self._configure_function = kwargs.pop("configure_function", None)
@@ -50,21 +50,36 @@ class SnapToplevel(tk.Toplevel):
         self._border = kwargs.pop("border", 40)
         self._offset_sides = kwargs.pop("offset_sides", None)
         self._offset_top = kwargs.pop("offset_top", None)
+        self._resizable = kwargs.pop("resizable", False)
+        self._allow_change = kwargs.pop("allow_change", False)
+
         # Tk.bind(self, event_name) returns an empty string if no function was bound to the event
         # It returns something like below if one was bound:
         # {"[55632584<lambda> %# %b %f %h %k %s %t %w %x %y %A %E %K %N %W %T %X %Y %D]" == "break"} break\n
         # This is probably because the implementation is not correct in the C bindings of Tkinter
         if not self._configure_function and not master.bind("<Configure>") == "":
             raise ValueError("No original Configure binding provided while one was bound to the master Tk instance.")
+
+        # Initialize Toplevel
         tk.Toplevel.__init__(self, master, **kwargs)
+
+        # Set the offset values
         offset_sides, offset_top = self.get_offset_values()
         self._offset_sides = self._offset_sides if self._offset_sides is not None else offset_sides
         self._offset_top = self._offset_top if self._offset_top is not None else offset_top
+
+        # Check if the keyword arguments are all valid values
+        self.check_keyword_arguments()
+
+        # Bind to <Configure>, <Map> and <Unmap> events
         self.bind("<Configure>", self.configure_callback)
         self.master.bind("<Configure>", self.configure_callback)
         self.master.bind("<Unmap>", self.minimize)
-        self.master.bind("<Map>")
+        self.master.bind("<Map>", self.deminimize)
+
+        # Get the current geometry of windows
         self._snapped = True
+        self._temp_lock = False
         self.update()
         self.master.update()
         self._geometry = self.wm_geometry()
@@ -79,8 +94,33 @@ class SnapToplevel(tk.Toplevel):
         self.configure_callback(Event())
 
         # Lift self to front, but focus master
-        self.deiconify()
-        self.master.focus_set()
+        self.deminimize(None)
+
+        # Set resizability
+        self.wm_resizable(self._resizable, self._resizable)
+
+    def check_keyword_arguments(self):
+        """
+        Check if all the attribute values set through arguments are valid
+        :raises: ValueError if an invalid value is found
+        """
+        if (self._location != tk.LEFT and self._location != tk.RIGHT and self._location != tk.TOP and
+                    self._location != tk.BOTTOM):
+            raise ValueError("location can only be set to tk.LEFT, tk.RIGHT, tk.TOP, tk.BOTTOM and not {}".
+                             format(self._location))
+        if not isinstance(self._locked, bool):
+            raise ValueError("locked can only be set to a bool value, not {}".format(self._locked))
+        if not isinstance(self._border, int):
+            raise ValueError("border can only be set to an int value, not {}".format(self._border))
+        if not isinstance(self._offset_sides, int):
+            raise ValueError("offset_sides can only be set to an int value, not {}".format(self._offset_sides))
+        if not isinstance(self._offset_top, int):
+            raise ValueError("offset_top can only be set to an int value, not {}".format(self._offset_top))
+        if not isinstance(self._resizable, bool):
+            raise ValueError("resizable can only be set to a bool value, not {}".format(self._resizable))
+        if not isinstance(self._allow_change, bool):
+            raise ValueError("allow_change can only be set to a bool value, not {}".format(self._allow_change))
+        return
 
     def minimize(self, event):
         """
@@ -93,6 +133,7 @@ class SnapToplevel(tk.Toplevel):
         Callback for a <Map> event on the master widget
         """
         self.deiconify()
+        self.master.focus_set()
 
     def configure_callback(self, event):
         """
@@ -108,40 +149,120 @@ class SnapToplevel(tk.Toplevel):
             self._configure_function(event)
 
     def _unlock(self):
-        self._locked = False
+        """
+        Function to unlock the temporary lock on movement
+        """
+        self._temp_lock = False
 
     def set_geometry_self(self):
-        if self._locked:
+        """
+        Set geometry when <Configure> is created with self as widget
+        """
+        distance_dictionary = self.get_distance_to_master()
+        # If the widget is locked, we want to reset the geometry to match the master widget
+        if self._locked or self._temp_lock:
             self.set_geometry_master()
-        else:
-            if self.wm_geometry() != self._geometry:
-                if self._snapped:
-                    self._geometry = self.wm_geometry()
-                    distance = self.get_distance_to_master()
-                    if distance > self._border:
-                        self._snapped = False
-                        pass
-                else:
-                    distance = self.get_distance_to_master()
-                    if distance < self._border:
-                        self._snapped = True
-                        self._locked = True
-                        self.after(500, self._unlock)
-                        self.set_geometry_master()
-            else:
+            return
+
+        elif self._snapped:
+            self._geometry = self.wm_geometry()
+            # If the minimum distance is larger than the border distance, the window is not snapped
+            if distance_dictionary[self._location] > self._border:
+                self._snapped = False
                 return
 
+        elif not self._allow_change:
+            # Changing of the anchor point is not allowed
+            if distance_dictionary[self._location] < self._border and not self._snapped:
+                self._snap()
+            else:
+                return
+        else:
+            # Changing of the anchor point is allowed
+            distance = min(distance_dictionary.values())
+            # Check if the anchor point as to be changed
+            if distance <= distance_dictionary[self._location] and distance < self._border + self._offset_sides:
+
+                for location, location_distance in distance_dictionary.items():
+                    if distance == location_distance:
+                        self._location = location
+                        self._snap()
+                        return
+            elif distance_dictionary[self._location] < self._border:
+                self._snap()
+        return
+
+    def _snap(self):
+        """
+        Function to set everything so the window can be snapped into place again
+        """
+        self._snapped = True
+        self._temp_lock = True
+        self.after(500, self._unlock)
+        self.set_geometry_master()
+
     def get_distance_to_master(self):
-        return max((abs(self.winfo_rootx() - self.master.winfo_rootx()) - self.winfo_width(),
-                    abs(self.winfo_rooty() - self.master.winfo_rooty()) - self.winfo_height()))
+        """
+        Return an int value of distance in pixels to the master window for each of the four sides
+        """
+        # Get the required values
+        master_left, master_right, master_top, master_bottom = self.get_points_sides_for_window(self.master)
+        self_left, self_right, self_top, self_bottom = self.get_points_sides_for_window(self)
+
+        # Calculate the distances
+        distance_left = self.get_distance_between_points(master_left, self_right)
+        distance_right = self.get_distance_between_points(master_right, self_left)
+        distance_top = self.get_distance_between_points(master_top, self_bottom)
+        distance_bottom = self.get_distance_between_points(master_bottom, self_top)
+
+        return {
+            tk.LEFT: distance_left,
+            tk.RIGHT: distance_right,
+            tk.TOP: distance_top,
+            tk.BOTTOM: distance_bottom
+        }
+
+    @staticmethod
+    def get_distance_between_points(point_one, point_two):
+        """
+        Calculate the distance in pixels between two points
+        :param point_one: (x, y)
+        :param point_two: (x, y)
+        :return: distance (int)
+        """
+        dx = abs(point_one[0] - point_two[0])
+        dy = abs(point_one[1] - point_two[1])
+        return int(sqrt(pow(dx, 2) + pow(dy, 2)))
+
+    @staticmethod
+    def get_points_sides_for_window(window):
+        """
+        Get the coordinates of the middle of each of the sides of a tkinter window (Toplevel or Tk)
+        """
+        master_width, master_height = window.winfo_width(), window.winfo_height()
+        master_rootx, master_rooty = window.winfo_rootx(), window.winfo_rooty()
+        master_left = (master_rootx, master_rooty + master_height // 2)
+        master_right = (master_rootx + master_width, master_rooty + master_height // 2)
+        master_bottom = (master_rootx + master_width // 2, master_rooty + master_height)
+        master_top = (master_rootx + master_width // 2, master_rooty)
+        return master_left, master_right, master_top, master_bottom
 
     def set_geometry_master(self):
         """
-        Function to calculate the new geometry of the window if it is snapped to the master and the master was moved
+        Function to set the new geometry of the window if it is snapped to the master and the master was moved
         """
         # If the Toplevel is not snapped to the window, we want to do nothing
         if not self.snapped:
             return
+        new_x, new_y, new_width, new_height = self.get_new_geometry_master()
+        if self._resizable:
+            new_width, new_height = self.winfo_width(), self.winfo_height()
+        self.wm_geometry("{}x{}+{}+{}".format(new_width, new_height, new_x, new_y))
+
+    def get_new_geometry_master(self):
+        """
+        Function to calculate the new geometry of the window
+        """
         master_x, master_y = self.master.winfo_x(), self.master.winfo_y()
         required_width, required_height = self.winfo_reqwidth(), self.winfo_reqheight()
         master_width, master_height = self.master.winfo_width(), self.master.winfo_height()
@@ -162,13 +283,13 @@ class SnapToplevel(tk.Toplevel):
             new_height = required_height
         elif self._location == tk.BOTTOM:
             new_x = master_x
-            new_y = master_y + required_height + self._offset_sides * 2
+            new_y = master_y + required_height + self._offset_top + self._offset_sides
             new_width = master_width
             new_height = required_height
         else:
             raise ValueError("Location is not a valid value: {0}. Was the private attribute altered?".
                              format(self._location))
-        self.wm_geometry("{}x{}+{}+{}".format(new_width, new_height, new_x, new_y))
+        return new_x, new_y, new_width, new_height
 
     def get_offset_values(self):
         """
@@ -197,5 +318,5 @@ class SnapToplevel(tk.Toplevel):
 
 if __name__ == '__main__':
     window = tk.Tk()
-    snap = SnapToplevel(window, location=tk.LEFT)
+    snap = SnapToplevel(window, allow_change=True)
     window.mainloop()

--- a/ttkwidgets/snaptoplevel.py
+++ b/ttkwidgets/snaptoplevel.py
@@ -31,7 +31,7 @@ class SnapToplevel(tk.Toplevel):
         :param master: master Tk instance
         :param kwargs: configure_function - callable object which has to be called upon a <Configure> event of either
                                             the master Tk instance or this SnapToplevel instance
-                       location           - either tk.LEFT, tk.RIGHT, tk.TOP or tk.BOTTOM - Location of the SnapToplevel
+                       anchor             - either tk.LEFT, tk.RIGHT, tk.TOP or tk.BOTTOM - Location of the SnapToplevel
                                             relative to the master Tk instance, defaults to tk.RIGHT
                        locked             - Whether the user is allowed to move the Toplevel at all
                        offset_sides       - Override default value
@@ -45,7 +45,7 @@ class SnapToplevel(tk.Toplevel):
         if not isinstance(master, tk.Tk):
             raise ValueError("SnapWindows can only be created with a Tk instance as master.")
         self._configure_function = kwargs.pop("configure_function", None)
-        self._location = kwargs.pop("location", tk.RIGHT)
+        self._anchor = kwargs.pop("anchor", tk.RIGHT)
         self._locked = kwargs.pop("locked", False)
         self._border = kwargs.pop("border", 40)
         self._offset_sides = kwargs.pop("offset_sides", None)
@@ -86,7 +86,7 @@ class SnapToplevel(tk.Toplevel):
         self._master_geometry = self.wm_geometry()
         self._distance = 0
 
-        # Call the configure function to set up initial location
+        # Call the configure function to set up initial anchor
         # First create a fake Tkinter event
         class Event(object):
             widget = self.master
@@ -104,10 +104,10 @@ class SnapToplevel(tk.Toplevel):
         Check if all the attribute values set through arguments are valid
         :raises: ValueError if an invalid value is found
         """
-        if (self._location != tk.LEFT and self._location != tk.RIGHT and self._location != tk.TOP and
-                    self._location != tk.BOTTOM):
-            raise ValueError("location can only be set to tk.LEFT, tk.RIGHT, tk.TOP, tk.BOTTOM and not {}".
-                             format(self._location))
+        if (self._anchor != tk.LEFT and self._anchor != tk.RIGHT and self._anchor != tk.TOP and
+                    self._anchor != tk.BOTTOM):
+            raise ValueError("anchor can only be set to tk.LEFT, tk.RIGHT, tk.TOP, tk.BOTTOM and not {}".
+                             format(self._anchor))
         if not isinstance(self._locked, bool):
             raise ValueError("locked can only be set to a bool value, not {}".format(self._locked))
         if not isinstance(self._border, int):
@@ -167,13 +167,13 @@ class SnapToplevel(tk.Toplevel):
         elif self._snapped:
             self._geometry = self.wm_geometry()
             # If the minimum distance is larger than the border distance, the window is not snapped
-            if distance_dictionary[self._location] > self._border:
+            if distance_dictionary[self._anchor] > self._border:
                 self._snapped = False
                 return
 
         elif not self._allow_change:
             # Changing of the anchor point is not allowed
-            if distance_dictionary[self._location] < self._border and not self._snapped:
+            if distance_dictionary[self._anchor] < self._border and not self._snapped:
                 self._snap()
             else:
                 return
@@ -181,14 +181,14 @@ class SnapToplevel(tk.Toplevel):
             # Changing of the anchor point is allowed
             distance = min(distance_dictionary.values())
             # Check if the anchor point as to be changed
-            if distance <= distance_dictionary[self._location] and distance < self._border + self._offset_sides:
+            if distance <= distance_dictionary[self._anchor] and distance < self._border + self._offset_sides:
 
-                for location, location_distance in distance_dictionary.items():
-                    if distance == location_distance:
-                        self._location = location
+                for anchor, anchor_distance in distance_dictionary.items():
+                    if distance == anchor_distance:
+                        self._anchor = anchor
                         self._snap()
                         return
-            elif distance_dictionary[self._location] < self._border:
+            elif distance_dictionary[self._anchor] < self._border:
                 self._snap()
         return
 
@@ -266,29 +266,29 @@ class SnapToplevel(tk.Toplevel):
         master_x, master_y = self.master.winfo_x(), self.master.winfo_y()
         required_width, required_height = self.winfo_reqwidth(), self.winfo_reqheight()
         master_width, master_height = self.master.winfo_width(), self.master.winfo_height()
-        if self._location == tk.RIGHT:
+        if self._anchor == tk.RIGHT:
             new_x = master_x + master_width + self._offset_sides * 2
             new_y = master_y
             new_width = required_width
             new_height = master_height
-        elif self._location == tk.LEFT:
+        elif self._anchor == tk.LEFT:
             new_x = master_x - required_width - self._offset_sides * 2
             new_y = master_y
             new_width = required_width
             new_height = master_height
-        elif self._location == tk.TOP:
+        elif self._anchor == tk.TOP:
             new_x = master_x
             new_y = master_y - required_height - self._offset_top - self._offset_sides
             new_width = master_width
             new_height = required_height
-        elif self._location == tk.BOTTOM:
+        elif self._anchor == tk.BOTTOM:
             new_x = master_x
             new_y = master_y + required_height + self._offset_top + self._offset_sides
             new_width = master_width
             new_height = required_height
         else:
             raise ValueError("Location is not a valid value: {0}. Was the private attribute altered?".
-                             format(self._location))
+                             format(self._anchor))
         return new_x, new_y, new_width, new_height
 
     def get_offset_values(self):

--- a/ttkwidgets/snaptoplevel.py
+++ b/ttkwidgets/snaptoplevel.py
@@ -42,8 +42,8 @@ class SnapToplevel(tk.Toplevel):
                        All other keyword arguments, such as width and height, are passed to the Toplevel
         """
         # Process given arguments
-        if not isinstance(master, tk.Tk):
-            raise ValueError("SnapWindows can only be created with a Tk instance as master.")
+        if not isinstance(master, tk.Tk) and not isinstance(master, tk.Toplevel):
+            raise ValueError("SnapWindows can only be created with a Tk or Toplevel instance as master.")
         self._configure_function = kwargs.pop("configure_function", None)
         self._anchor = kwargs.pop("anchor", tk.RIGHT)
         self._locked = kwargs.pop("locked", False)
@@ -105,7 +105,7 @@ class SnapToplevel(tk.Toplevel):
         :raises: ValueError if an invalid value is found
         """
         if (self._anchor != tk.LEFT and self._anchor != tk.RIGHT and self._anchor != tk.TOP and
-                    self._anchor != tk.BOTTOM):
+                self._anchor != tk.BOTTOM):
             raise ValueError("anchor can only be set to tk.LEFT, tk.RIGHT, tk.TOP, tk.BOTTOM and not {}".
                              format(self._anchor))
         if not isinstance(self._locked, bool):

--- a/ttkwidgets/snaptoplevel.py
+++ b/ttkwidgets/snaptoplevel.py
@@ -341,8 +341,3 @@ class SnapToplevel(tk.Toplevel):
     @property
     def snapped(self):
         return self._snapped
-
-if __name__ == '__main__':
-    window = tk.Tk()
-    snap = SnapToplevel(window, allow_change=True)
-    window.mainloop()

--- a/ttkwidgets/snaptoplevel.py
+++ b/ttkwidgets/snaptoplevel.py
@@ -139,12 +139,12 @@ class SnapToplevel(tk.Toplevel):
         """
         The callback for the <Configure> Tkinter event, generated when a window is moved or resized.
         """
-        if event.widget is self.master:
-            self.set_geometry_master()
-        elif event.widget is self:
-            self.set_geometry_self()
-        else:
-            return
+        # First check if an update is necessary
+        if self._master_geometry != self.master.wm_geometry() or self._geometry != self.wm_geometry():
+            if event.widget is self.master:
+                self.set_geometry_master()
+            elif event.widget is self:
+                self.set_geometry_self()
         if callable(self._configure_function):
             self._configure_function(event)
 

--- a/ttkwidgets/snaptoplevel.py
+++ b/ttkwidgets/snaptoplevel.py
@@ -303,11 +303,37 @@ class SnapToplevel(tk.Toplevel):
         offset_top = abs(content_y - root_y)
         return offset_sides, offset_top
 
-    def cget(self, *args):
-        pass
+    def cget(self, key):
+        if key == "configure_function":
+            return self._configure_function
+        elif key == "anchor":
+            return self._anchor
+        elif key == "locked":
+            return self._locked
+        elif key == "border":
+            return self._border
+        elif key == "offset_sides":
+            return self._offset_sides
+        elif key == "offset_top":
+            return self._offset_top
+        elif key == "resizable":
+            return self._resizable
+        elif key == "allow_change":
+            return self._allow_change
+        else:
+            return tk.Toplevel.cget(self, key)
 
     def config(self, **kwargs):
-        pass
+        self._configure_function = kwargs.pop("configure_function", self._configure_function)
+        self._anchor = kwargs.pop("anchor", self._anchor)
+        self._locked = kwargs.pop("locked", self._locked)
+        self._border = kwargs.pop("border", self._border)
+        self._offset_sides = kwargs.pop("offset_sides", self._offset_sides)
+        self._offset_top = kwargs.pop("offset_top", self._offset_top)
+        self._resizable = kwargs.pop("resizable", self._resizable)
+        self._allow_change = kwargs.pop("allow_change", self._allow_change)
+        self.check_keyword_arguments()
+        return tk.Toplevel.config(self, **kwargs)
 
     def configure(self, **kwargs):
         self.config(**kwargs)

--- a/ttkwidgets/snaptoplevel.py
+++ b/ttkwidgets/snaptoplevel.py
@@ -1,0 +1,146 @@
+"""
+Author: RedFantom
+License: GNU GPLv3
+Source: This repository
+"""
+try:
+    import Tkinter as tk
+    import ttk
+except ImportError:
+    import tkinter as tk
+    from tkinter import ttk
+
+# TODO: Implement the automatic snap-in-place when Toplevel is brought close to the window again
+# TODO: Allow the user to move the Toplevel to a different location on the window
+# TODO: Allow the developer to lock the SnapToplevel in place
+
+
+class SnapToplevel(tk.Toplevel):
+    """
+    A Toplevel window that can be snapped to a side of the Tk instance
+
+    At first glance, the code doesn't allow multiple of these to be opened at the same time (see the second ValueError),
+    but it can be worked around if it is actually the intention of the programmer to have multiple of these. This can be
+    done by unbinding <Configure> from the master instance before opening, and after that rebinding to a function that
+    calls the configure_callback functions of all SnapToplevel instances, and then calling the original <Configure>
+    callback of the master window, if present.
+
+    Is not guaranteed to work on all platforms due to Tkinter event and window manager restrictions. Functionality
+    depends on whether a <Configure> event is generated upon moving the Tk instance.
+    """
+    def __init__(self, master, **kwargs):
+        """
+        :param master: master Tk instance
+        :param kwargs: configure_function - callable object which has to be called upon a <Configure> event of either
+                                            the master Tk instance or this SnapToplevel instance
+                       location           - either tk.LEFT, tk.RIGHT, tk.TOP or tk.BOTTOM - Location of the SnapToplevel
+                                            relative to the master Tk instance, defaults to tk.RIGHT
+                       offset             - A custom offset in pixels for the window. The platform the user is using
+                                            may call for different values. For the tk.TOP location, the top_offset value
+                                            is used.
+                       top_offset         - The offset for the tk.TOP position
+                       locked             - Whether the user is allowed to move the Toplevel at all
+                       All other keyword arguments, such as width and height, are passed to the Toplevel
+        """
+        if not isinstance(master, tk.Tk):
+            raise ValueError("SnapWindows can only be created with a Tk instance as master.")
+        self._configure_function = kwargs.pop("configure_function", None)
+        self._location = kwargs.pop("location", tk.RIGHT)
+        # TODO: Gather different offset values for different platforms
+        """
+        Windows 7: 15, 37 pixels (no DPI scaling)
+        """
+        self._offset = kwargs.pop("offset", 15)
+        self._top_offset = kwargs.pop("top_offset", 37)
+        if not isinstance(self._offset, int):
+            raise ValueError("offset option must be of int type. Given value is of {0} type.".
+                             format(type(self._offset)))
+        # Tk.bind(self, event_name) returns an empty string if no function was bound to the event
+        # It returns something like below if one was bound:
+        # {"[55632584<lambda> %# %b %f %h %k %s %t %w %x %y %A %E %K %N %W %T %X %Y %D]" == "break"} break\n
+        # This is probably because the implementation is not correct in the C bindings of Tkinter
+        if not self._configure_function and not master.bind("<Configure>") == "":
+            raise ValueError("No original Configure binding provided while one was bound to the master Tk instance.")
+        tk.Toplevel.__init__(self, master, **kwargs)
+        self.bind("<Configure>", self.configure_callback)
+        self.master.bind("<Configure>", self.configure_callback)
+        self.master.bind("<Unmap>", self.minimize)
+        self.master.bind("<Map>")
+
+        # Call the configure function to set up initial location
+        # First create a fake Tkinter event
+        class Event(object):
+            widget = self.master
+        self.configure_callback(Event())
+        # Lift self to front
+        self.deiconify()
+
+    def minimize(self, event):
+        """
+        Callback for an <Unmap> event on the master widget
+        """
+        self.wm_iconify()
+
+    def deminimize(self, event):
+        """
+        Callback for a <Map> event on the master widget
+        """
+        self.deiconify()
+
+    def configure_callback(self, event):
+        """
+        The callback for the <Configure> Tkinter event, generated when a window is moved or resized.
+        """
+        if event.widget is self.master:
+            new_width, new_height, new_x, new_y = self.calculate_geometry_master()
+        elif event.widget is self:
+            return
+        else:
+            return
+        self.wm_geometry("{}x{}+{}+{}".format(new_width, new_height, new_x, new_y))
+        self.lift()
+        if callable(self._configure_function):
+            self._configure_function(event)
+
+    def calculate_geometry_master(self):
+        """
+        Function to calculate the new geometry of the window
+        """
+        if not isinstance(self.master, tk.Tk):
+            raise ValueError()
+        master_x, master_y = self.master.winfo_x(), self.master.winfo_y()
+        required_width, required_height = self.winfo_reqwidth(), self.winfo_reqheight()
+        master_width, master_height = self.master.winfo_width(), self.master.winfo_height()
+        if self._location == tk.RIGHT:
+            new_x = master_x + master_width + self._offset
+            new_y = master_y
+            new_width = required_width
+            new_height = master_height
+        elif self._location == tk.LEFT:
+            new_x = master_x - required_width - self._offset
+            new_y = master_y
+            new_width = required_width
+            new_height = master_height
+        elif self._location == tk.TOP:
+            new_x = master_x
+            new_y = master_y - required_height - self._top_offset
+            new_width = master_width
+            new_height = required_height
+        elif self._location == tk.BOTTOM:
+            new_x = master_x
+            new_y = master_y + required_height + self._offset
+            new_width = master_width
+            new_height = required_height
+        else:
+            raise ValueError("Location is not a valid value: {0}. Was the private attribute altered?".
+                             format(self._location))
+        return new_width, new_height, new_x, new_y
+
+
+if __name__ == '__main__':
+    window = tk.Tk()
+    snap = SnapToplevel(window, location=tk.TOP)
+    window.mainloop()
+
+
+


### PR DESCRIPTION
This branch contains a `SnapToplevel` widget, which can automatically snap in to place next to its parent window. As parent window, a `Tk` or `Toplevel` instance is allowed. Various keyword arguments are available to control the behaviour of the Toplevel. After being snapped into place, the widget is automatically locked for a period of `500ms` to allow the user time to release his left mouse button, so the widget is not immediately de-snapped again. The widget can be snapped on all four sides of the parent window, and resizes when this happens.