### PR TITLE
Merge debugwindow+ into master to add DebugWindow text wrapping

### DIFF
--- a/example_debugwindow.py
+++ b/example_debugwindow.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) RedFantom 2017
+# Copyright (c) Juliette Monsel 2017
+# For license see LICENSE
+
+from ttkwidgets import debugwindow
+try:
+    import Tkinter as tk
+    import ttk
+except ImportError:
+    import tkinter as tk
+    from tkinter import ttk
+
+root = tk.Tk()
+ttk.Button(root, text="Print ok", command=lambda: print('ok'*50)).pack()
+debugwindow.DebugWindow(root)
+root.mainloop()

--- a/examples/example_debugwindow.py
+++ b/examples/example_debugwindow.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) RedFantom 2017
+# Copyright (c) Juliette Monsel 2017
+# For license see LICENSE
+
+from ttkwidgets import debugwindow
+try:
+    import Tkinter as tk
+    import ttk
+except ImportError:
+    import tkinter as tk
+    from tkinter import ttk
+
+root = tk.Tk()
+ttk.Button(root, text="Print ok", command=lambda: print('ok')).pack()
+debugwindow.DebugWindow(root)
+root.mainloop()

--- a/tests/test_debugwindow.py
+++ b/tests/test_debugwindow.py
@@ -37,3 +37,4 @@ class TestDebugWindow(BaseWidgetTest):
         with open("somefile.txt", "r") as f:
             self.assertTrue("Something!" in f.read())
         os.remove('somefile.txt')
+

--- a/ttkwidgets/debugwindow.py
+++ b/ttkwidgets/debugwindow.py
@@ -18,7 +18,8 @@ class DebugWindow(tk.Toplevel):
     """
     A Toplevel that shows sys.stdout and sys.stderr for Tkinter applications
     """
-    def __init__(self, master=None, title="Debug window", stdout=True, stderr=False, **kwargs):
+    def __init__(self, master=None, title="Debug window", stdout=True, stderr=False, width=70, **kwargs):
+        self._width = width
         tk.Toplevel.__init__(self, master, **kwargs)
         self.wm_title(title)
         if stdout:
@@ -31,7 +32,7 @@ class DebugWindow(tk.Toplevel):
         self.filemenu.add_command(label="Save file", command=self.save)
         self.filemenu.add_command(label="Exit", command=self.destroy)
         self.menu.add_cascade(label="File", menu=self.filemenu)
-        self.text = tk.Text(self)
+        self.text = tk.Text(self, width=width)
         self.scroll = ttk.Scrollbar(self, orient=tk.VERTICAL, command=self.text.yview)
         self.text.config(yscrollcommand=self.scroll.set)
         self.text.bind("<Key>", lambda e: "break")
@@ -49,7 +50,14 @@ class DebugWindow(tk.Toplevel):
         self.scroll.grid(row=0, column=1, sticky="ns")
 
     def write(self, line):
-        self.text.insert(tk.END, line)
+        while True:
+            if len(line) <= self._width:
+                self.text.insert(tk.END, line)
+                break
+            else:
+                sub = line[:self._width]
+                self.text.insert(tk.END, sub)
+                self.text.insert(tk.END, "\n")
 
 
 if __name__ == '__main__':

--- a/ttkwidgets/debugwindow.py
+++ b/ttkwidgets/debugwindow.py
@@ -21,7 +21,10 @@ class DebugWindow(tk.Toplevel):
     def __init__(self, master=None, title="Debug window", stdout=True, stderr=False, width=70, **kwargs):
         self._width = width
         tk.Toplevel.__init__(self, master, **kwargs)
+        self.protocol("WM_DELETE_WINDOW", self.quit)
         self.wm_title(title)
+        self._oldstdout = sys.stdout
+        self._oldstderr = sys.stderr
         if stdout:
             sys.stdout = self
         if stderr:
@@ -30,7 +33,7 @@ class DebugWindow(tk.Toplevel):
         self.config(menu=self.menu)
         self.filemenu = tk.Menu(self.menu, tearoff=0)
         self.filemenu.add_command(label="Save file", command=self.save)
-        self.filemenu.add_command(label="Exit", command=self.destroy)
+        self.filemenu.add_command(label="Exit", command=self.quit)
         self.menu.add_cascade(label="File", menu=self.filemenu)
         self.text = tk.Text(self, width=width)
         self.scroll = ttk.Scrollbar(self, orient=tk.VERTICAL, command=self.text.yview)
@@ -59,6 +62,8 @@ class DebugWindow(tk.Toplevel):
                 self.text.insert(tk.END, sub)
                 self.text.insert(tk.END, "\n")
 
-
-if __name__ == '__main__':
-    DebugWindow().mainloop()
+    def quit(self):
+        """Restore previous stdout/stderr and destroy the window."""
+        sys.stdout = self._oldstdout
+        sys.stderr = self._oldstderr
+        self.destroy()

--- a/ttkwidgets/debugwindow.py
+++ b/ttkwidgets/debugwindow.py
@@ -62,6 +62,9 @@ class DebugWindow(tk.Toplevel):
                 self.text.insert(tk.END, sub)
                 self.text.insert(tk.END, "\n")
 
+    def flush(self):
+        pass
+
     def quit(self):
         """Restore previous stdout/stderr and destroy the window."""
         sys.stdout = self._oldstdout

--- a/ttkwidgets/debugwindow.py
+++ b/ttkwidgets/debugwindow.py
@@ -35,7 +35,7 @@ class DebugWindow(tk.Toplevel):
         self.filemenu.add_command(label="Save file", command=self.save)
         self.filemenu.add_command(label="Exit", command=self.quit)
         self.menu.add_cascade(label="File", menu=self.filemenu)
-        self.text = tk.Text(self, width=width)
+        self.text = tk.Text(self, width=width, wrap=tk.WORD)
         self.scroll = ttk.Scrollbar(self, orient=tk.VERTICAL, command=self.text.yview)
         self.text.config(yscrollcommand=self.scroll.set)
         self.text.bind("<Key>", lambda e: "break")
@@ -53,14 +53,7 @@ class DebugWindow(tk.Toplevel):
         self.scroll.grid(row=0, column=1, sticky="ns")
 
     def write(self, line):
-        while True:
-            if len(line) <= self._width:
-                self.text.insert(tk.END, line)
-                break
-            else:
-                sub = line[:self._width]
-                self.text.insert(tk.END, sub)
-                self.text.insert(tk.END, "\n")
+        self.text.insert(tk.END, line)
 
     def flush(self):
         pass


### PR DESCRIPTION
In addition to adding texxt wrapping, this also adds a new keyword argument to `DebugWindow`, specifically the `width` argument, which is passed to the `Text` widget and also used for the text wrapping.