### PR TITLE
Merge tickscale into master to add TickScale

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,5 +18,6 @@ This file contains a list of all the authors of widgets in this repository. Plea
   * `AutocompleteCombobox`, found [here](https://mail.python.org/pipermail/tkinter-discuss/2012-January/003041.html)
 - [Juliette Monsel](https://www.github.com/j4321)
   * `CheckboxTreeview`
+  * `TickScale`
   * `AutoHideScrollbar` based on an idea by [Fredrik Lundh](effbot.org/zone/tkinter-autoscrollbar.htm)
-  * All color widgets: `askcolor`, `ColorPicker`, `GradientBar` and `ColorSquare`, `LimitVar`, `SpinBox`, `AlphaBar` and supporting functions in `functions.py`. 
+  * All color widgets: `askcolor`, `ColorPicker`, `GradientBar` and `ColorSquare`, `LimitVar`, `SpinBox`, `AlphaBar` and supporting functions in `functions.py`.

--- a/examples/example_tickscale.py
+++ b/examples/example_tickscale.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) RedFantom 2017
+# Copyright (c) Juliette Monsel 2017
 # For license see LICENSE
 from ttkwidgets import TickScale
 try:
@@ -13,9 +13,9 @@ except ImportError:
 
 root = tk.Tk()
 style = ttk.Style(root)
-style.configure('my.Vertical.TScale', sliderlength=10, background='white',
+style.configure('my.Vertical.TScale', sliderlength=50, background='white',
                 foreground='red')
-style.configure('my.Horizontal.TScale', sliderlength=50,
+style.configure('my.Horizontal.TScale', sliderlength=10,
                 font='TkDefaultFont 20 italic')
 s1 = TickScale(root, orient='vertical', style='my.Vertical.TScale',
                tickinterval=0.2, from_=-1, to=1, showvalue=True, digits=2,
@@ -23,9 +23,8 @@ s1 = TickScale(root, orient='vertical', style='my.Vertical.TScale',
 s2 = TickScale(root, orient='horizontal', style='my.Horizontal.TScale',
                from_=0, to=10, tickinterval=2, resolution=1,
                showvalue=True, length=300)
-s3 = TickScale(root, orient='horizontal', style='my.Horizontal.TScale',
-               from_=0.25, to=1, tickinterval=0.1, resolution=0.1,
-               showvalue=True, length=300)
+s3 = TickScale(root, orient='horizontal', from_=0.25, to=1, tickinterval=0.1,
+               resolution=0.1)
 
 s1.pack(fill='y')
 s2.pack(fill='x')

--- a/examples/example_tickscale.py
+++ b/examples/example_tickscale.py
@@ -19,7 +19,7 @@ style.configure('my.Horizontal.TScale', sliderlength=50,
                 font='TkDefaultFont 20 italic')
 s1 = TickScale(root, orient='vertical', style='my.Vertical.TScale',
                tickinterval=0.2, from_=-1, to=1, showvalue=True, digits=2,
-               length=400)
+               length=400, labelpos='e')
 s2 = TickScale(root, orient='horizontal', style='my.Horizontal.TScale',
                from_=0, to=10, tickinterval=2, showvalue=True, length=300)
 

--- a/examples/example_tickscale.py
+++ b/examples/example_tickscale.py
@@ -21,9 +21,14 @@ s1 = TickScale(root, orient='vertical', style='my.Vertical.TScale',
                tickinterval=0.2, from_=-1, to=1, showvalue=True, digits=2,
                length=400, labelpos='e')
 s2 = TickScale(root, orient='horizontal', style='my.Horizontal.TScale',
-               from_=0, to=10, tickinterval=2, showvalue=True, length=300)
+               from_=0, to=10, tickinterval=2, resolution=1,
+               showvalue=True, length=300)
+s3 = TickScale(root, orient='horizontal', style='my.Horizontal.TScale',
+               from_=0.25, to=1, tickinterval=0.1, resolution=0.1,
+               showvalue=True, length=300)
 
 s1.pack(fill='y')
 s2.pack(fill='x')
+s3.pack(fill='x')
 
 root.mainloop()

--- a/examples/example_tickscale.py
+++ b/examples/example_tickscale.py
@@ -13,7 +13,7 @@ except ImportError:
 
 root = tk.Tk()
 style = ttk.Style(root)
-#style.theme_use('clam')
+style.theme_use('clam')
 style.configure('my.Vertical.TScale', sliderlength=50, background='white',
                 foreground='red')
 style.configure('my.Horizontal.TScale', sliderlength=10,

--- a/examples/example_tickscale.py
+++ b/examples/example_tickscale.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) RedFantom 2017
+# For license see LICENSE
+from ttkwidgets import TickScale
+try:
+    import Tkinter as tk
+    import ttk
+except ImportError:
+    import tkinter as tk
+    from tkinter import ttk
+
+
+root = tk.Tk()
+style = ttk.Style(root)
+style.configure('my.Vertical.TScale', sliderlength=10, background='white',
+                foreground='red')
+style.configure('my.Horizontal.TScale', sliderlength=50,
+                font='TkDefaultFont 20 italic')
+s1 = TickScale(root, orient='vertical', style='my.Vertical.TScale',
+               tickinterval=0.2, from_=-1, to=1, showvalue=True, digits=2,
+               length=400)
+s2 = TickScale(root, orient='horizontal', style='my.Horizontal.TScale',
+               from_=0, to=10, tickinterval=2, showvalue=True, length=300)
+
+s1.pack(fill='y')
+s2.pack(fill='x')
+
+root.mainloop()

--- a/examples/example_tickscale.py
+++ b/examples/example_tickscale.py
@@ -13,6 +13,7 @@ except ImportError:
 
 root = tk.Tk()
 style = ttk.Style(root)
+#style.theme_use('clam')
 style.configure('my.Vertical.TScale', sliderlength=50, background='white',
                 foreground='red')
 style.configure('my.Horizontal.TScale', sliderlength=10,
@@ -22,7 +23,7 @@ s1 = TickScale(root, orient='vertical', style='my.Vertical.TScale',
                length=400, labelpos='e')
 s2 = TickScale(root, orient='horizontal', style='my.Horizontal.TScale',
                from_=0, to=10, tickinterval=2, resolution=1,
-               showvalue=True, length=300)
+               showvalue=True, length=400)
 s3 = TickScale(root, orient='horizontal', from_=0.25, to=1, tickinterval=0.1,
                resolution=0.1)
 

--- a/tests/test_tickscale.py
+++ b/tests/test_tickscale.py
@@ -1,0 +1,97 @@
+# Copyright (c) RedFantom 2017
+# For license see LICENSE
+from ttkwidgets import TickScale
+from tests import BaseWidgetTest
+try:
+    import Tkinter as tk
+    import ttk
+except ImportError:
+    import tkinter as tk
+    from tkinter import ttk
+
+
+class TestTickScale(BaseWidgetTest):
+    def test_tickscale_init(self):
+        TickScale(self.window, orient='vertical', style='my.Vertical.TScale',
+                  tickinterval=0.2, from_=-1, to=1, showvalue=True,
+                  digits=2, length=400, cursor='watch').pack()
+        self.window.update()
+        TickScale(self.window, orient='horizontal', from_=0, to=10,
+                  tickinterval=0, showvalue=False,
+                  command=lambda value: print(value)).pack()
+        self.window.update()
+
+    def test_tickscale_methods(self):
+        scale = TickScale(self.window, from_=0, to=10, orient='horizontal')
+        scale.pack()
+        self.window.update()
+        self.assertEqual(scale.cget('digits'), 0)
+        self.assertEqual(scale['tickinterval'], 0)
+        self.assertTrue(scale.cget('showvalue'))
+        self.assertEqual(scale['from'], 0)
+        self.assertEqual(scale.cget('to'), 10)
+        keys = ['command',
+                'variable',
+                'orient',
+                'from',
+                'to',
+                'value',
+                'length',
+                'takefocus',
+                'cursor',
+                'style',
+                'class',
+                'tickinterval',
+                'showvalue',
+                'digits']
+        self.assertEqual(sorted(scale.keys()), sorted(keys))
+
+        scale.config(from_=-1)
+        self.window.update()
+        self.assertEqual(scale['from'], -1)
+
+        scale.configure({'to': 20, 'tickinterval': 5, 'digits': 1})
+        self.window.update()
+        self.assertEqual(scale['to'], 20)
+        self.assertEqual(scale['digits'], 1)
+        self.assertEqual(scale['tickinterval'], 5)
+
+        scale['orient'] = 'vertical'
+        self.window.update()
+
+        style = ttk.Style(self.window)
+        scale.configure(style='my.Vertical.TScale')
+        self.window.update()
+        style.configure('my.Vertical.TScale', font='TkDefaultFont 20 italic',
+                        sliderlength=50)
+
+        scale.x = 0
+
+        def cmd(value):
+            scale.x = 2 * float(value)
+
+        scale.configure(command=cmd)
+        self.window.update()
+        scale.set(10)
+        self.window.update()
+        self.assertEqual(scale.x, 20)
+        self.assertEqual(scale.label.cget('text'), '10.0')
+
+        scale['showvalue'] = False
+        self.window.update()
+        self.assertEqual(scale.label.place_info(), {})
+
+        scale['orient'] = 'horizontal'
+        self.window.update()
+        scale['style'] = ''
+        scale['showvalue'] = True
+        self.window.update()
+        scale['length'] = 200
+        scale['digits'] = 3
+        style.configure('Horizontal.TScale', font='TkDefaultFont 20 italic',
+                        sliderlength=10)
+        self.window.update()
+        scale.set(0)
+        self.window.update()
+        scale.set(20)
+        self.window.update()

--- a/tests/test_tickscale.py
+++ b/tests/test_tickscale.py
@@ -17,8 +17,7 @@ class TestTickScale(BaseWidgetTest):
                   digits=2, length=400, cursor='watch').pack()
         self.window.update()
         TickScale(self.window, orient='horizontal', from_=0, to=10,
-                  tickinterval=0, showvalue=False,
-                  command=lambda value: print(value)).pack()
+                  tickinterval=0, showvalue=False).pack()
         self.window.update()
 
     def test_tickscale_methods(self):

--- a/tests/test_tickscale.py
+++ b/tests/test_tickscale.py
@@ -17,8 +17,18 @@ class TestTickScale(BaseWidgetTest):
                   digits=2, length=400, cursor='watch').pack()
         self.window.update()
         TickScale(self.window, orient='horizontal', from_=0, to=10,
-                  tickinterval=0, showvalue=False).pack()
+                  tickinterval=0, tickpos='n', labelpos='s',
+                  showvalue=False).pack()
         self.window.update()
+
+        with self.assertRaises(ValueError):
+            TickScale(self.window, orient='vertical', tickpos='n')
+
+        with self.assertRaises(ValueError):
+            TickScale(self.window, orient='horizontal', tickpos='e')
+
+        with self.assertRaises(ValueError):
+            TickScale(self.window, labelpos='ne')
 
     def test_tickscale_methods(self):
         scale = TickScale(self.window, from_=0, to=10, orient='horizontal')
@@ -55,14 +65,42 @@ class TestTickScale(BaseWidgetTest):
         self.assertEqual(scale['digits'], 1)
         self.assertEqual(scale['tickinterval'], 5)
 
+        scale['labelpos'] = 's'
+        self.window.update()
+        self.assertEqual(scale['labelpos'], 's')
+
+        scale['labelpos'] = 'e'
+        self.window.update()
+        self.assertEqual(scale['labelpos'], 'e')
+
+        scale['labelpos'] = 'w'
+        self.window.update()
+        self.assertEqual(scale['labelpos'], 'w')
+
+        scale['tickpos'] = 'n'
+        self.window.update()
+        self.assertEqual(scale['tickpos'], 'n')
+
         scale['orient'] = 'vertical'
         self.window.update()
 
-        style = ttk.Style(self.window)
+        scale['tickpos'] = 'e'
+        self.window.update()
+        self.assertEqual(scale['tickpos'], 'e')
+
+        with self.assertRaises(ValueError):
+            scale.configure(orient='vertical', tickpos='n')
+
+        with self.assertRaises(ValueError):
+            scale.configure(orient='horizontal', tickpos='e')
+
+        with self.assertRaises(ValueError):
+            TickScale(self.window, labelpos='ne')
+
         scale.configure(style='my.Vertical.TScale')
         self.window.update()
-        style.configure('my.Vertical.TScale', font='TkDefaultFont 20 italic',
-                        sliderlength=50)
+        scale.style.configure('my.Vertical.TScale', font='TkDefaultFont 20 italic',
+                              sliderlength=50)
 
         scale.x = 0
 
@@ -87,8 +125,8 @@ class TestTickScale(BaseWidgetTest):
         self.window.update()
         scale['length'] = 200
         scale['digits'] = 3
-        style.configure('Horizontal.TScale', font='TkDefaultFont 20 italic',
-                        sliderlength=10)
+        scale.style.configure('Horizontal.TScale', font='TkDefaultFont 20 italic',
+                              sliderlength=10)
         self.window.update()
         scale.set(0)
         self.window.update()

--- a/tests/test_tickscale.py
+++ b/tests/test_tickscale.py
@@ -34,8 +34,9 @@ class TestTickScale(BaseWidgetTest):
         scale = TickScale(self.window, from_=0, to=10, orient='horizontal')
         scale.pack()
         self.window.update()
-        self.assertEqual(scale.cget('digits'), 0)
+        self.assertEqual(scale.cget('digits'), -1)
         self.assertEqual(scale['tickinterval'], 0)
+        self.assertEqual(scale['resolution'], 0)
         self.assertTrue(scale.cget('showvalue'))
         self.assertEqual(scale['from'], 0)
         self.assertEqual(scale.cget('to'), 10)
@@ -64,6 +65,15 @@ class TestTickScale(BaseWidgetTest):
         self.assertEqual(scale['to'], 20)
         self.assertEqual(scale['digits'], 1)
         self.assertEqual(scale['tickinterval'], 5)
+
+        scale.configure(tickinterval=0.01, resolution=0.05)
+        self.window.update()
+        self.assertEqual(scale['digits'], 2)
+        self.assertEqual(scale['resolution'], 0.05)
+        self.assertEqual(scale['tickinterval'], 0.05)
+
+        scale.set(1.1036247)
+        self.assertEqual(scale.get(), 1.10)
 
         scale['labelpos'] = 's'
         self.window.update()
@@ -109,6 +119,7 @@ class TestTickScale(BaseWidgetTest):
 
         scale.configure(command=cmd)
         self.window.update()
+        scale.configure(digits=1)
         scale.set(10)
         self.window.update()
         self.assertEqual(scale.x, 20)

--- a/ttkwidgets/__init__.py
+++ b/ttkwidgets/__init__.py
@@ -7,3 +7,4 @@ from ttkwidgets.scrolledlistbox import ScrolledListbox
 from ttkwidgets.debugwindow import DebugWindow
 from ttkwidgets.checkboxtreeview import CheckboxTreeview
 from ttkwidgets.itemscanvas import ItemsCanvas
+from ttkwidgets.tickscale import TickScale

--- a/ttkwidgets/tickscale.py
+++ b/ttkwidgets/tickscale.py
@@ -91,7 +91,7 @@ class TickScale(ttk.Frame):
         else:
             if self._digits is None:
                 self._digits = d
-            if self._digits >= 0 and self._digits < d:
+            if 0 <= self._digits < d:
                 self._resolution = float('1e-{}'.format(self._digits))
                 self._tickinterval = round(self._tickinterval, self._digits)
                 if self._resolution > self._tickinterval:

--- a/ttkwidgets/tickscale.py
+++ b/ttkwidgets/tickscale.py
@@ -1,3 +1,8 @@
+"""
+Author: Juliette Monsel
+License: GNU GPLv3
+Source: This repository
+"""
 try:
     import Tkinter as tk
     import ttk

--- a/ttkwidgets/tickscale.py
+++ b/ttkwidgets/tickscale.py
@@ -182,6 +182,17 @@ class TickScale(ttk.Frame):
     def configure(self, cnf={}, **kw):
         kw.update(cnf)
         reinit = False
+        if 'orient' in kw:
+            if kw['orient'] == 'vertical':
+                self._style_name = self._style_name.replace('Horizontal', 'Vertical')
+                if 'tickpos' not in kw:
+                    self._tickpos = 'w'
+            else:
+                self._style_name = self._style_name.replace('Vertical', 'Horizontal')
+                if 'tickpos' not in kw:
+                    self._tickpos = 's'
+            self.scale.configure(style=self._style_name)
+            reinit = True
         if 'showvalue' in kw:
             self._showvalue = bool(kw.pop('showvalue'))
             reinit = True
@@ -276,17 +287,6 @@ class TickScale(ttk.Frame):
             self._style_name = kw['style']
             if not self._style_name:
                 self._style_name = '%s.TScale' % (str(self.scale.cget('orient')).capitalize())
-        if 'orient' in kw:
-            if kw['orient'] == 'vertical':
-                self._style_name = self._style_name.replace('Horizontal', 'Vertical')
-                if 'tickpos' not in kw:
-                    self._tickpos = 'w'
-            else:
-                self._style_name = self._style_name.replace('Vertical', 'Horizontal')
-                if 'tickpos' not in kw:
-                    self._tickpos = 's'
-            self.scale.configure(style=self._style_name)
-            reinit = True
         if reinit:
             self._init()
         if 'orient' in kw:

--- a/ttkwidgets/tickscale.py
+++ b/ttkwidgets/tickscale.py
@@ -306,42 +306,77 @@ class TickScale(ttk.Frame):
         return percent * (self.get_scale_length() - self._sliderlength) + self._sliderlength / 2
 
     def _update_slider_length_horizontal(self):
-        """Measure the length of the slider and update the value of self._sliderlength."""
+        """
+        Measure the length of the slider and update the value of self._sliderlength.
+
+        self.scale.identify(x, y) is used to find the first and last pixels of
+        the slider. Indeed, self.scale.identify(x, y) returns the element
+        of the ttk.Scale to which the pixel (x, y) belongs. So, the length of
+        the slider is determined by scanning horizontally the pixels of the scale.
+        """
         if not self.scale.identify(2, 2):
-            # to soon, wait for the scale to be properly displayed
+            # if self.scale.identify(2, 2) is an empty string it means that the scale
+            # is not displayed yet so we cannot measure the length of the slider,
+            # so wait for the scale to be properly displayed.
             # binding to <Map> event does not work, it can still be to soon to
             # get any result from identify
             self.after(10, self._update_slider_length_horizontal)
         else:
             w = self.scale.winfo_width()
             i = 0
+            # find the first pixel of the slider
             while i < w and 'slider' not in self.scale.identify(i, 2):
+                # increment i until the pixel (i, 2) belongs to the slider
                 i += 1
             j = i
+            # find the last pixel of the slider
             while j < w and 'slider' in self.scale.identify(j, 2):
+                # increment j until the pixel (2, j) no longer belongs to the slider
                 j += 1
             if j == i:
+                # the length of the slider was not determined properly,
+                # so the value of the sliderlength from the style is used
                 self._sliderlength = self.style.lookup(self._style_name, 'sliderlength', default=30)
             else:
+                # update ticks and label placement
                 self._sliderlength = j - i
             self._update_display()
 
     def _update_slider_length_vertical(self):
-        """Measure the length of the slider and update the value of self._sliderlength."""
+        """
+        Measure the length of the slider and update the value of self._sliderlength.
+
+        self.scale.identify(x, y) is used to find the first and last pixels of
+        the slider. Indeed, self.scale.identify(x, y) returns the element
+        of the ttk.Scale to which the pixel (x, y) belongs. So, the length of
+        the slider is determined by scanning vertically the pixels of the scale.
+        """
         if not self.scale.identify(2, 2):
+            # if self.scale.identify(2, 2) is an empty string it means that the scale
+            # is not displayed yet so we cannot measure the length of the slider,
+            # so wait for the scale to be properly displayed.
+            # binding to <Map> event does not work, it can still be to soon to
+            # get any result from identify
             self.after(10, self._update_slider_length_vertical)
         else:
             h = self.scale.winfo_height()
             i = 0
-            while i < h and 'slider' not in self.scale.identify(1, i):
+            # find the first pixel of the slider
+            while i < h and 'slider' not in self.scale.identify(2, i):
+                # increment i until the pixel (2, i) belongs to the slider
                 i += 1
             j = i
-            while j < h and 'slider' in self.scale.identify(1, j):
+            # find the last pixel of the slider
+            while j < h and 'slider' in self.scale.identify(2, j):
+                # increment j until the pixel (2, j) no longer belongs to the slider
                 j += 1
             if j == i:
+                # the length of the slider was not determined properly,
+                # so the value of the sliderlength from the style is used
                 self._sliderlength = self.style.lookup(self._style_name, 'sliderlength', default=30)
             else:
                 self._sliderlength = j - i
+            # update ticks and label placement
             self._update_display()
 
     def _apply_style(self):

--- a/ttkwidgets/tickscale.py
+++ b/ttkwidgets/tickscale.py
@@ -197,7 +197,7 @@ class TickScale(ttk.Frame):
         if self._tickinterval:
             self.ticks = []
             self.ticklabels = []
-            nb_interv = round(self._extent / self._tickinterval)
+            nb_interv = int(round(self._extent / self._tickinterval))
             for i in range(nb_interv + 1):
                 tick = self._start + i * self._tickinterval
                 self.ticks.append(tick)

--- a/ttkwidgets/tickscale.py
+++ b/ttkwidgets/tickscale.py
@@ -18,22 +18,59 @@ class TickScale(ttk.Frame):
         Arguments:
             * master: parent window
             * showvalue: display current value next to the slider
+            * labelpos: if showvalue is True, position of the label:
+                n, s, e, w
             * tickinterval: if not 0, display ticks with the given interval
-            * digits: number of digits after the comma to display, default is 0
+            * tickpos: if tickinterval is not 0, position of the ticks:
+                vertical scale: w or e
+                horizontal scale: n or s
+            * digits: number of digits after the comma to display, if negative
+                use the %g format
             * all ttk.Scale options:
                 class, cursor, style, takefocus, command, from, length, orient,
                 to, value, variable
+
+                The style must derive from Vertical.TScale or Horizontal.TScale
+                depending on the orientation.
         """
         ttk.Frame.__init__(self, master, class_='TickScale', padding=2)
+        self.rowconfigure(0, weight=1)
+        self.columnconfigure(0, weight=1)
         self._showvalue = kwargs.pop('showvalue', True)
         self._tickinterval = kwargs.pop('tickinterval', 0)
-        self._digits = kwargs.pop('digits', 0)
-        self._command = kwargs.get('command', lambda value: None)
 
-        self._formatter = '{:.' + str(self._digits) + 'f}'
+        interv = str(self._tickinterval)
+        self._digits = kwargs.pop('digits', interv[::-1].find('.'))
+        if not isinstance(self._digits, int):
+            raise TypeError("'digits' must be an integer or None.")
+
+        if 'digits' not in kwargs and self._digits < 0:
+            if 'e' not in interv:
+                self._digits = 0
+                self._formatter = '{:.' + str(self._digits) + 'f}'
+            else:
+                self._formatter = '{:g}'
+        elif self._digits < 0:
+            self._formatter = '{:g}'
+        else:
+            self._formatter = '{:.' + str(self._digits) + 'f}'
+
+        self._command = kwargs.get('command', lambda value: None)
+        orient = kwargs.get('orient', 'horizontal')
+        self._labelpos = kwargs.pop('labelpos',
+                                    'n' if orient == 'horizontal' else 'w')
+        if self._labelpos not in ['w', 'e', 'n', 's']:
+            raise ValueError("'labelpos' must be 'n', 's', 'e', or 'w'.")
+        self._tickpos = kwargs.pop('tickpos',
+                                   's' if orient == 'horizontal' else 'w')
 
         self.style = ttk.Style(self)
         self.scale = ttk.Scale(self, **kwargs)
+
+        if orient == 'vertical' and self._tickpos not in ['w', 'e']:
+            raise ValueError("For a vertical TickScale, 'tickpos' must be 'w' or 'e'.")
+        elif orient == 'horizontal' and self._tickpos not in ['n', 's']:
+            raise ValueError("For a horizontal TickScale, 'tickpos' must be 'n' or 's'.")
 
         self._style_name = self.scale.cget('style')
         if not self._style_name:
@@ -43,10 +80,10 @@ class TickScale(ttk.Frame):
         self._start = kwargs['from_']
         self.ticks = []
         self.ticklabels = []
-        self.label = ttk.Label(self)
+        self.label = ttk.Label(self, padding=1)
 
-        self._init()
         self._apply_style()
+        self._init()
 
         def cmd(value):
             self._command(value)
@@ -78,6 +115,10 @@ class TickScale(ttk.Frame):
             return self._showvalue
         elif key == 'tickinterval':
             return self._tickinterval
+        elif key == 'tickpos':
+            return self._tickpos
+        elif key == 'labelpos':
+            return self._labelpos
         elif key == 'digits':
             return self._digits
         else:
@@ -87,15 +128,40 @@ class TickScale(ttk.Frame):
         kw.update(cnf)
         reinit = False
         if 'showvalue' in kw:
-            self._showvalue = kw.pop('showvalue')
+            self._showvalue = bool(kw.pop('showvalue'))
             reinit = True
         if 'tickinterval' in kw:
             self._tickinterval = kw.pop('tickinterval')
             reinit = True
+        if 'tickpos' in kw:
+            tickpos = kw.pop('tickpos')
+            orient = kw.get('orient', str(self.cget('orient')))
+            if orient == 'vertical' and tickpos not in ['w', 'e']:
+                raise ValueError("For a vertical TickScale, 'tickpos' must be 'w' or 'e'.")
+            elif orient == 'horizontal' and tickpos not in ['n', 's']:
+                raise ValueError("For a horizontal TickScale, 'tickpos' must be 'n' or 's'.")
+            elif orient in ['vertical', 'horizontal']:
+                self._tickpos = tickpos
+                reinit = True
+        if 'labelpos' in kw:
+            labelpos = kw.pop('labelpos')
+            if labelpos not in ['w', 'e', 'n', 's']:
+                raise ValueError("'labelpos' must be 'n', 's', 'e' or 'w'.")
+            else:
+                self._labelpos = labelpos
+                reinit = True
         if 'digits' in kw:
-            self._digits = kw.pop('digits')
-            self._formatter = '{:.' + str(self._digits) + 'f}'
-            reinit = True
+            digits = kw.pop('digits')
+            if not isinstance(digits, int):
+                raise TypeError("'digits' must be an integer.")
+            elif digits < 0:
+                self._digits = digits
+                self._formatter = '{:g}'
+                reinit = True
+            else:
+                self._digits = digits
+                self._formatter = '{:.' + str(self._digits) + 'f}'
+                reinit = True
         self.scale.configure(**kw)
         if 'from_' in kw or 'from' in kw or 'to' in kw:
             self._extent = self.scale.cget('to') - self.scale.cget('from')
@@ -117,8 +183,12 @@ class TickScale(ttk.Frame):
         if 'orient' in kw:
             if kw['orient'] == 'vertical':
                 self._style_name = self._style_name.replace('Horizontal', 'Vertical')
+                if 'tickpos' not in kw:
+                    self._tickpos = 'w'
             else:
                 self._style_name = self._style_name.replace('Vertical', 'Horizontal')
+                if 'tickpos' not in kw:
+                    self._tickpos = 's'
             self.scale.configure(style=self._style_name)
             reinit = True
         if reinit:
@@ -165,6 +235,8 @@ class TickScale(ttk.Frame):
         for label in self.ticklabels:
             label.destroy()
         self.label.place_forget()
+        self.ticks = []
+        self.ticklabels = []
         if str(self.scale.cget('orient')) == "horizontal":
             self.get_scale_length = self.scale.winfo_width
             self.display_value = self._display_value_horizontal
@@ -178,86 +250,192 @@ class TickScale(ttk.Frame):
 
     def _init_vertical(self):
         """Create and grid the widgets for a vertical orientation."""
-        self.rowconfigure(0, weight=1)
         self.scale.grid(row=0, sticky='ns')
-        padx1, padx2 = 0, 0
+        self.update_idletasks()
         # showvalue
+        padx1, padx2 = 0, 0
+        pady1, pady2 = 0, 0
         if self._showvalue:
             self.label.configure(text=self._formatter.format(self._start))
-            self.label.place(in_=self.scale, bordermode='outside', x=-1, y=0,
-                             anchor='e')
-            self.update_idletasks()
-            padx1 = self.label.winfo_width()
-            self.label.configure(text=self._formatter.format(self._start + self._extent))
-            self.update_idletasks()
-            padx1 = max(self.label.winfo_width(), padx1) + 1
+            if self._labelpos == 'w':
+                self.label.place(in_=self.scale, bordermode='outside',
+                                 relx=0, y=0, anchor='e')
+                self.update_idletasks()
+                padx1 = self.label.winfo_width()
+                self.label.configure(text=self._formatter.format(self._start + self._extent))
+                self.update_idletasks()
+                padx1 = max(self.label.winfo_width(), padx1)
+            elif self._labelpos == 'e':
+                self.label.place(in_=self.scale, bordermode='outside',
+                                 relx=1, y=1, anchor='w')
+                self.update_idletasks()
+                padx2 = self.label.winfo_width()
+                self.label.configure(text=self._formatter.format(self._start + self._extent))
+                self.update_idletasks()
+                padx2 = max(self.label.winfo_width(), padx2)
+            else:  # self._labelpos in ['n', 's']:
+                if self._labelpos == 'n':
+                    rely = 0
+                    anchor = 's'
+                    pady1 = self.label.winfo_reqheight()
+                else:
+                    rely = 1
+                    anchor = 'n'
+                    pady2 = self.label.winfo_reqheight()
+                self.label.place(in_=self.scale, bordermode='outside', relx=0.5,
+                                 rely=rely, anchor=anchor)
+                self.update_idletasks()
+                w = self.label.winfo_width()
+                self.label.configure(text=self._formatter.format(self._start + self._extent))
+                self.update_idletasks()
+                w = max(w, self.label.winfo_width())
+                ws = self.scale.winfo_reqwidth()
+                if w > ws:
+                    padx = (w - ws) // 2
+                    if self._tickinterval:
+                        if self._tickpos == 'e':
+                            padx1 = padx
+                        else:   # self._tickpos == 'w'
+                            padx2 = padx
+                    else:
+                        padx1, padx2 = padx, padx
+
             self._display_value_vertical(self.scale.get())
 
         # ticks
+        padx1_2, padx2_2 = 0, 0
         if self._tickinterval:
-            self.ticks = []
-            self.ticklabels = []
             nb_interv = int(round(self._extent / self._tickinterval))
-            for i in range(nb_interv + 1):
-                tick = self._start + i * self._tickinterval
-                self.ticks.append(tick)
-                self.ticklabels.append(ttk.Label(self, text=self._formatter.format(tick)))
-                self.ticklabels[i].place(in_=self.scale, bordermode='outside',
-                                         x=-1 - padx1, y=0,
-                                         anchor='e')
-                self.update_idletasks()
-                padx2 = max(self.ticklabels[i].winfo_width(), padx2)
+            if self._tickpos == 'w':
+                for i in range(nb_interv + 1):
+                    tick = self._start + i * self._tickinterval
+                    self.ticks.append(tick)
+                    self.ticklabels.append(ttk.Label(self,
+                                                     style=self._style_name + ".TLabel",
+                                                     text=self._formatter.format(tick)))
+                    self.ticklabels[i].place(in_=self.scale, bordermode='outside',
+                                             x=-1 - padx1, y=0,
+                                             anchor='e')
+                    self.update_idletasks()
+                    padx1_2 = max(self.ticklabels[i].winfo_width(), padx1_2)
+            else:  # self._tickpos == 'e'
+                w = self.scale.winfo_reqwidth()
+                for i in range(nb_interv + 1):
+                    tick = self._start + i * self._tickinterval
+                    self.ticks.append(tick)
+                    self.ticklabels.append(ttk.Label(self,
+                                                     style=self._style_name + ".TLabel",
+                                                     text=self._formatter.format(tick)))
+                    self.ticklabels[i].place(in_=self.scale, bordermode='outside',
+                                             x=w + 1 + padx2, y=0,
+                                             anchor='w')
+                    self.update_idletasks()
+                    padx2_2 = max(self.ticklabels[i].winfo_width(), padx2_2)
             self._place_ticks_vertical()
-        self.scale.grid_configure(padx=(padx1 + padx2 + 1, 0), pady=0)
+        self.scale.grid_configure(padx=(padx1 + padx1_2 + 1, padx2 + padx2_2 + 1),
+                                  pady=(pady1, pady2))
 
     def _init_horizontal(self):
         """Create and grid the widgets for a horizontal orientation."""
-        self.columnconfigure(0, weight=1)
+        self.scale.grid(row=0, sticky='ew')
+        padx1, padx2 = 0, 0
         pady1, pady2 = 0, 0
         # showvalue
         if self._showvalue:
             self.label.configure(text=self._formatter.format(self._start))
-            self.label.place(in_=self.scale, bordermode='outside', x=0, y=0, anchor='s')
-            pady1 = self._display_value_horizontal(self.scale.get())
+            self.update_idletasks()
+            if self._labelpos == 'n':
+                self.label.place(in_=self.scale, bordermode='outside',
+                                 rely=0, x=0, anchor='s')
+                pady1 = self.label.winfo_reqheight()
+            elif self._labelpos == 's':
+                self.label.place(in_=self.scale, bordermode='outside',
+                                 rely=1, x=0, anchor='n')
+                pady2 = self.label.winfo_reqheight()
+            elif self._labelpos in ['w', 'e']:
+                padx = self.label.winfo_reqwidth()
+                self.label.configure(text=self._formatter.format(self._start + self._extent))
+                self.update_idletasks()
+                padx = max(padx, self.label.winfo_reqwidth())
+                if self._labelpos == 'w':
+                    anchor = 'e'
+                    relx = 0
+                    padx1 = padx
+                else:
+                    anchor = 'w'
+                    relx = 1
+                    padx2 = padx
+                self.label.place(in_=self.scale, bordermode='outside',
+                                 relx=relx, rely=0.5, anchor=anchor)
 
-        self.scale.grid(row=0, sticky='ew')
+                h = self.label.winfo_reqheight()
+                hs = self.scale.winfo_reqheight()
+                if h > hs:
+                    pady = (h - hs) // 2
+                    if self._tickinterval:
+                        if self._tickpos == 'n':
+                            pady1 = pady
+                        else:   # self._tickpos == 's'
+                            pady2 = pady
+                    else:
+                        pady1, pady2 = pady, pady
+
+            self._display_value_horizontal(self.scale.get())
 
         # ticks
+        pady1_2, pady2_2 = 0, 0
         if self._tickinterval:
-            self.ticks = []
-            self.ticklabels = []
             nb_interv = int(round(self._extent / self._tickinterval))
-            for i in range(nb_interv + 1):
-                tick = self._start + i * self._tickinterval
-                self.ticks.append(tick)
-                self.ticklabels.append(ttk.Label(self, text=self._formatter.format(tick)))
-                self.ticklabels[i].place(in_=self.scale, bordermode='outside', x=0, rely=1, anchor='n')
-            pady2 = self._place_ticks_horizontal()
-        self.scale.grid_configure(pady=(pady1, pady2), padx=0)
+            h = self.scale.winfo_reqheight()
+            if self._tickpos == 's':
+                for i in range(nb_interv + 1):
+                    tick = self._start + i * self._tickinterval
+                    self.ticks.append(tick)
+                    self.ticklabels.append(ttk.Label(self,
+                                                     style=self._style_name + ".TLabel",
+                                                     text=self._formatter.format(tick)))
+                    self.ticklabels[i].place(in_=self.scale, bordermode='outside',
+                                             x=0, y=h + pady2 + 1, anchor='n')
+                pady2_2 = self.ticklabels[-1].winfo_reqheight()
+            else:  # self._tickpos == 'n':
+                for i in range(nb_interv + 1):
+                    tick = self._start + i * self._tickinterval
+                    self.ticks.append(tick)
+                    self.ticklabels.append(ttk.Label(self,
+                                                     style=self._style_name + ".TLabel",
+                                                     text=self._formatter.format(tick)))
+                    self.ticklabels[i].place(in_=self.scale, bordermode='outside',
+                                             x=0, y=-1 - pady1, anchor='s')
+                pady1_2 = self.ticklabels[-1].winfo_reqheight()
+            self._place_ticks_horizontal()
+        self.scale.grid_configure(pady=(pady1 + pady1_2, pady2 + pady2_2),
+                                  padx=(padx1, padx2))
 
     def _display_value_horizontal(self, value):
-        pad = 0
         if self._showvalue:
-            # position (in pixel) of the center of the slider
-            x = self.convert_to_pixels(float(value))
-            # pay attention to the borders
-            half_width = self.label.winfo_width() / 2
-            if x + half_width > self.scale.winfo_width():
-                x = self.scale.winfo_width() - half_width
-            elif x - half_width < 0:
-                x = half_width
-            self.label.place_configure(x=x)
             self.label.configure(text=self._formatter.format(float(value)))
             self.update_idletasks()
-            pad = self.label.winfo_height()
-        return pad
+            if self._labelpos in ['n', 's']:
+                # position (in pixel) of the center of the slider
+                x = self.convert_to_pixels(float(value))
+                # pay attention to the borders
+                half_width = self.label.winfo_width() / 2
+                if x + half_width > self.scale.winfo_width():
+                    x = self.scale.winfo_width() - half_width
+                elif x - half_width < 0:
+                    x = half_width
+                self.label.place_configure(x=x)
 
     def _display_value_vertical(self, value):
+        """
+        Display the current value and update the label position.
+        Return the pady necessary to display the label.
+        """
         if self._showvalue:
-            y = self.convert_to_pixels(float(value))
-            self.label.place_configure(y=y)
             self.label.configure(text=self._formatter.format(float(value)))
-        return 0
+            if self._labelpos in ['e', 'w']:
+                y = self.convert_to_pixels(float(value))
+                self.label.place_configure(y=y)
 
     def _place_ticks_horizontal(self):
         # first tick
@@ -281,30 +459,26 @@ class TickScale(ttk.Frame):
             x = self.scale.winfo_width() - half_width
         label.place_configure(x=x)
         self.update_idletasks()
-        return label.winfo_height()
 
     def _place_ticks_vertical(self):
         for tick, label in zip(self.ticks, self.ticklabels):
             y = self.convert_to_pixels(tick)
             label.place_configure(y=y)
-        return 0
 
     def _style_change(self, event=None):
         """Apply style and update widgets position."""
         self._apply_style()
+        self._init()
         self.update_idletasks()
         self._update_slider_length()
-        self._update_display(event)
 
     def _update_display(self, event):
         """Redisplay the ticks and the label so that they adapt to the new size of the scale."""
-        pady1, pady2 = 0, 0
         try:
             if self._showvalue:
-                pady1 = self.display_value(self.scale.get())
+                self.display_value(self.scale.get())
             if self._tickinterval:
-                pady2 = self.place_ticks()
-        except tk.TclError:
-            # happens when configure is called during an orientation change
+                self.place_ticks()
+        except Exception:
+            # happens when configure is called during an configuration change
             pass
-        self.scale.grid_configure(pady=(pady1, pady2))

--- a/ttkwidgets/tickscale.py
+++ b/ttkwidgets/tickscale.py
@@ -591,6 +591,7 @@ class TickScale(ttk.Frame):
                                   padx=(padx1, padx2))
 
     def _display_value_horizontal(self, value):
+        """Display the current value and update the label position."""
         if self._showvalue:
             self.label.configure(text=self._formatter.format(float(value)))
             self.update_idletasks()
@@ -606,10 +607,7 @@ class TickScale(ttk.Frame):
                 self.label.place_configure(x=x)
 
     def _display_value_vertical(self, value):
-        """
-        Display the current value and update the label position.
-        Return the pady necessary to display the label.
-        """
+        """Display the current value and update the label position."""
         if self._showvalue:
             self.label.configure(text=self._formatter.format(float(value)))
             if self._labelpos in ['e', 'w']:
@@ -617,6 +615,7 @@ class TickScale(ttk.Frame):
                 self.label.place_configure(y=y)
 
     def _place_ticks_horizontal(self):
+        """Display the ticks for a horizontal scale."""
         # first tick
         tick = self.ticks[0]
         label = self.ticklabels[0]
@@ -639,6 +638,7 @@ class TickScale(ttk.Frame):
         label.place_configure(x=x)
 
     def _place_ticks_vertical(self):
+        """Display the ticks for a vertical slider."""
         for tick, label in zip(self.ticks, self.ticklabels):
             y = self.convert_to_pixels(tick)
             label.place_configure(y=y)

--- a/ttkwidgets/tickscale.py
+++ b/ttkwidgets/tickscale.py
@@ -1,0 +1,310 @@
+try:
+    import Tkinter as tk
+    import ttk
+except ImportError:
+    from tkinter import ttk
+    import tkinter as tk
+
+
+class TickScale(ttk.Frame):
+    """
+    A ttk.Scale that can display the current value next to the slider and
+    supports ticks.
+    """
+    def __init__(self, master=None, **kwargs):
+        """
+        Create a TickScale with parent master.
+
+        Arguments:
+            * master: parent window
+            * showvalue: display current value next to the slider
+            * tickinterval: if not 0, display ticks with the given interval
+            * digits: number of digits after the comma to display, default is 0
+            * all ttk.Scale options:
+                class, cursor, style, takefocus, command, from, length, orient,
+                to, value, variable
+        """
+        ttk.Frame.__init__(self, master, class_='TickScale', padding=2)
+        self._showvalue = kwargs.pop('showvalue', True)
+        self._tickinterval = kwargs.pop('tickinterval', 0)
+        self._digits = kwargs.pop('digits', 0)
+        self._command = kwargs.get('command', lambda value: None)
+
+        self._formatter = '{:.' + str(self._digits) + 'f}'
+
+        self.style = ttk.Style(self)
+        self.scale = ttk.Scale(self, **kwargs)
+
+        self._style_name = self.scale.cget('style')
+        if not self._style_name:
+            self._style_name = '%s.TScale' % (str(self.scale.cget('orient')).capitalize())
+        self._update_slider_length()
+        self._extent = kwargs['to'] - kwargs['from_']
+        self._start = kwargs['from_']
+        self.ticks = []
+        self.ticklabels = []
+        self.label = ttk.Label(self)
+
+        self._init()
+        self._apply_style()
+
+        def cmd(value):
+            self._command(value)
+            self.display_value(value)
+
+        self.scale.configure(command=cmd)
+
+        self.scale.bind('<Configure>', self._update_display)
+        self.scale.bind('<<ThemeChanged>>', self._style_change)
+
+        self.get = self.scale.get
+        self.set = self.scale.set
+        self.coords = self.scale.coords
+        self.instate = self.scale.instate
+        self.state = self.scale.state
+
+    def __getitem__(self, item):
+        return self.cget(item)
+
+    def __setitem__(self, item, value):
+        self.configure({item: value})
+
+    def keys(self):
+        keys = self.scale.keys()
+        return keys + ['showvalue', 'tickinterval', 'digits']
+
+    def cget(self, key):
+        if key == 'showvalue':
+            return self._showvalue
+        elif key == 'tickinterval':
+            return self._tickinterval
+        elif key == 'digits':
+            return self._digits
+        else:
+            return self.scale.cget(key)
+
+    def configure(self, cnf={}, **kw):
+        kw.update(cnf)
+        reinit = False
+        if 'showvalue' in kw:
+            self._showvalue = kw.pop('showvalue')
+            reinit = True
+        if 'tickinterval' in kw:
+            self._tickinterval = kw.pop('tickinterval')
+            reinit = True
+        if 'digits' in kw:
+            self._digits = kw.pop('digits')
+            self._formatter = '{:.' + str(self._digits) + 'f}'
+            reinit = True
+        self.scale.configure(**kw)
+        if 'from_' in kw or 'from' in kw or 'to' in kw:
+            self._extent = self.scale.cget('to') - self.scale.cget('from')
+            self._start = self.scale.cget('from')
+            reinit = True
+        if 'style' in kw:
+            self._style_name = kw['style']
+            if not self._style_name:
+                self._style_name = '%s.TScale' % (str(self.scale.cget('orient')).capitalize())
+            self._style_change()
+        if 'command' in kw:
+            self._command = kw['command']
+
+            def cmd(value):
+                self._command(value)
+                self.display_value(value)
+
+            self.scale.configure(command=cmd)
+        if 'orient' in kw:
+            if kw['orient'] == 'vertical':
+                self._style_name = self._style_name.replace('Horizontal', 'Vertical')
+            else:
+                self._style_name = self._style_name.replace('Vertical', 'Horizontal')
+            self.scale.configure(style=self._style_name)
+            reinit = True
+        if reinit:
+            self._init()
+
+            def cmd(value):
+                self._command(value)
+                self.display_value(value)
+
+            self.scale.configure(command=cmd)
+
+    def config(self, cnf={}, **kw):
+        self.configure(cnf={}, **kw)
+
+    def convert_to_pixels(self, value):
+        """Convert value in the scale's unit into a position in pixels."""
+        percent = ((value - self._start) / self._extent)
+        return percent * (self.get_scale_length() - self._sliderlength) + self._sliderlength / 2
+
+    def _update_slider_length(self):
+        self._sliderlength = self.style.lookup(self._style_name, 'sliderlength', default=30)
+
+    def _apply_style(self):
+        """Apply the scale style to the frame and labels."""
+        ttk.Frame.configure(self, style=self._style_name + ".TFrame")
+        self.label.configure(style=self._style_name + ".TLabel")
+        for label in self.ticklabels:
+            label.configure(style=self._style_name + ".TLabel")
+        self.style.configure(self._style_name + ".TFrame",
+                             background=self.style.lookup(self._style_name, 'background'))
+        self.style.map(self._style_name + ".TFrame",
+                       background=self.style.map(self._style_name, 'background'))
+        self.style.configure(self._style_name + ".TLabel",
+                             font=self.style.lookup(self._style_name, 'font'),
+                             background=self.style.lookup(self._style_name, 'background'),
+                             foreground=self.style.lookup(self._style_name, 'foreground'))
+        self.style.map(self._style_name + ".TLabel",
+                       font=self.style.map(self._style_name, 'font'),
+                       background=self.style.map(self._style_name, 'background'),
+                       foreground=self.style.map(self._style_name, 'foreground'))
+
+    def _init(self):
+        """Create and grid the widgets."""
+        for label in self.ticklabels:
+            label.destroy()
+        self.label.place_forget()
+        if str(self.scale.cget('orient')) == "horizontal":
+            self.get_scale_length = self.scale.winfo_width
+            self.display_value = self._display_value_horizontal
+            self.place_ticks = self._place_ticks_horizontal
+            self._init_horizontal()
+        else:
+            self.get_scale_length = self.scale.winfo_height
+            self.display_value = self._display_value_vertical
+            self.place_ticks = self._place_ticks_vertical
+            self._init_vertical()
+
+    def _init_vertical(self):
+        """Create and grid the widgets for a vertical orientation."""
+        self.rowconfigure(0, weight=1)
+        self.scale.grid(row=0, sticky='ns')
+        padx1, padx2 = 0, 0
+        # showvalue
+        if self._showvalue:
+            self.label.configure(text=self._formatter.format(self._start))
+            self.label.place(in_=self.scale, bordermode='outside', x=-1, y=0,
+                             anchor='e')
+            self.update_idletasks()
+            padx1 = self.label.winfo_width()
+            self.label.configure(text=self._formatter.format(self._start + self._extent))
+            self.update_idletasks()
+            padx1 = max(self.label.winfo_width(), padx1) + 1
+            self._display_value_vertical(self.scale.get())
+
+        # ticks
+        if self._tickinterval:
+            self.ticks = []
+            self.ticklabels = []
+            nb_interv = round(self._extent / self._tickinterval)
+            for i in range(nb_interv + 1):
+                tick = self._start + i * self._tickinterval
+                self.ticks.append(tick)
+                self.ticklabels.append(ttk.Label(self, text=self._formatter.format(tick)))
+                self.ticklabels[i].place(in_=self.scale, bordermode='outside',
+                                         x=-1 - padx1, y=0,
+                                         anchor='e')
+                self.update_idletasks()
+                padx2 = max(self.ticklabels[i].winfo_width(), padx2)
+            self._place_ticks_vertical()
+        self.scale.grid_configure(padx=(padx1 + padx2 + 1, 0), pady=0)
+
+    def _init_horizontal(self):
+        """Create and grid the widgets for a horizontal orientation."""
+        self.columnconfigure(0, weight=1)
+        pady1, pady2 = 0, 0
+        # showvalue
+        if self._showvalue:
+            self.label.configure(text=self._formatter.format(self._start))
+            self.label.place(in_=self.scale, bordermode='outside', x=0, y=0, anchor='s')
+            pady1 = self._display_value_horizontal(self.scale.get())
+
+        self.scale.grid(row=0, sticky='ew')
+
+        # ticks
+        if self._tickinterval:
+            self.ticks = []
+            self.ticklabels = []
+            nb_interv = round(self._extent / self._tickinterval)
+            for i in range(nb_interv + 1):
+                tick = self._start + i * self._tickinterval
+                self.ticks.append(tick)
+                self.ticklabels.append(ttk.Label(self, text=self._formatter.format(tick)))
+                self.ticklabels[i].place(in_=self.scale, bordermode='outside', x=0, rely=1, anchor='n')
+            pady2 = self._place_ticks_horizontal()
+        self.scale.grid_configure(pady=(pady1, pady2), padx=0)
+
+    def _display_value_horizontal(self, value):
+        pad = 0
+        if self._showvalue:
+            # position (in pixel) of the center of the slider
+            x = self.convert_to_pixels(float(value))
+            # pay attention to the borders
+            half_width = self.label.winfo_width() / 2
+            if x + half_width > self.scale.winfo_width():
+                x = self.scale.winfo_width() - half_width
+            elif x - half_width < 0:
+                x = half_width
+            self.label.place_configure(x=x)
+            self.label.configure(text=self._formatter.format(float(value)))
+            self.update_idletasks()
+            pad = self.label.winfo_height()
+        return pad
+
+    def _display_value_vertical(self, value):
+        if self._showvalue:
+            y = self.convert_to_pixels(float(value))
+            self.label.place_configure(y=y)
+            self.label.configure(text=self._formatter.format(float(value)))
+        return 0
+
+    def _place_ticks_horizontal(self):
+        # first tick
+        tick = self.ticks[0]
+        label = self.ticklabels[0]
+        x = self.convert_to_pixels(tick)
+        half_width = label.winfo_width() / 2
+        if x - half_width < 0:
+            x = half_width
+        label.place_configure(x=x)
+        # ticks in the middle
+        for tick, label in zip(self.ticks[1:-1], self.ticklabels[1:-1]):
+            x = self.convert_to_pixels(tick)
+            label.place_configure(x=x)
+        # last tick
+        tick = self.ticks[-1]
+        label = self.ticklabels[-1]
+        x = self.convert_to_pixels(tick)
+        half_width = label.winfo_width() / 2
+        if x + half_width > self.scale.winfo_width():
+            x = self.scale.winfo_width() - half_width
+        label.place_configure(x=x)
+        self.update_idletasks()
+        return label.winfo_height()
+
+    def _place_ticks_vertical(self):
+        for tick, label in zip(self.ticks, self.ticklabels):
+            y = self.convert_to_pixels(tick)
+            label.place_configure(y=y)
+        return 0
+
+    def _style_change(self, event=None):
+        """Apply style and update widgets position."""
+        self._apply_style()
+        self.update_idletasks()
+        self._update_slider_length()
+        self._update_display(event)
+
+    def _update_display(self, event):
+        """Redisplay the ticks and the label so that they adapt to the new size of the scale."""
+        pady1, pady2 = 0, 0
+        try:
+            if self._showvalue:
+                pady1 = self.display_value(self.scale.get())
+            if self._tickinterval:
+                pady2 = self.place_ticks()
+        except tk.TclError:
+            # happens when configure is called during an orientation change
+            pass
+        self.scale.grid_configure(pady=(pady1, pady2))

--- a/ttkwidgets/tickscale.py
+++ b/ttkwidgets/tickscale.py
@@ -226,7 +226,7 @@ class TickScale(ttk.Frame):
         if self._tickinterval:
             self.ticks = []
             self.ticklabels = []
-            nb_interv = round(self._extent / self._tickinterval)
+            nb_interv = int(round(self._extent / self._tickinterval))
             for i in range(nb_interv + 1):
                 tick = self._start + i * self._tickinterval
                 self.ticks.append(tick)

--- a/ttkwidgets/tickscale.py
+++ b/ttkwidgets/tickscale.py
@@ -276,7 +276,6 @@ class TickScale(ttk.Frame):
             self._style_name = kw['style']
             if not self._style_name:
                 self._style_name = '%s.TScale' % (str(self.scale.cget('orient')).capitalize())
-            self._style_change()
         if 'orient' in kw:
             if kw['orient'] == 'vertical':
                 self._style_name = self._style_name.replace('Horizontal', 'Vertical')
@@ -290,6 +289,9 @@ class TickScale(ttk.Frame):
             reinit = True
         if reinit:
             self._init()
+        if 'orient' in kw:
+            # needed after the reinitialization in case of orientation change
+            self._apply_style()
 
     def config(self, cnf={}, **kw):
         self.configure(cnf=cnf, **kw)

--- a/ttkwidgets/tickscale.py
+++ b/ttkwidgets/tickscale.py
@@ -320,7 +320,7 @@ class TickScale(ttk.Frame):
             j = i
             while j < w and 'slider' in self.scale.identify(j, 2):
                 j += 1
-            if j - i == 0:
+            if j == i:
                 self._sliderlength = self.style.lookup(self._style_name, 'sliderlength', default=30)
             else:
                 self._sliderlength = j - i
@@ -338,7 +338,7 @@ class TickScale(ttk.Frame):
             j = i
             while j < h and 'slider' in self.scale.identify(1, j):
                 j += 1
-            if j - i == 0:
+            if j == i:
                 self._sliderlength = self.style.lookup(self._style_name, 'sliderlength', default=30)
             else:
                 self._sliderlength = j - i

--- a/ttkwidgets/tickscale.py
+++ b/ttkwidgets/tickscale.py
@@ -292,7 +292,7 @@ class TickScale(ttk.Frame):
             self._init()
 
     def config(self, cnf={}, **kw):
-        self.configure(cnf={}, **kw)
+        self.configure(cnf=cnf, **kw)
 
     def get(self):
         if self._digits >= 0:

--- a/ttkwidgets/tickscale.py
+++ b/ttkwidgets/tickscale.py
@@ -125,7 +125,7 @@ class TickScale(ttk.Frame):
 
         try:
             self._trace = self._var.trace_add('write', self._increment)
-        except Exception:
+        except AttributeError:
             # backward compatibility
             self._trace = self._var.trace('w', self._increment)
 
@@ -262,7 +262,7 @@ class TickScale(ttk.Frame):
                 kw['variable'] = self._var
             try:
                 self._var.trace_add('write', self._increment)
-            except Exception:
+            except AttributeError:
                 # backward compatibility
                 self._var.trace('w', self._increment)
 
@@ -428,7 +428,7 @@ class TickScale(ttk.Frame):
         try:
             self._var.trace_remove('write', self._trace)
             self._trace = self._var.trace_add('write', self._increment)
-        except Exception:
+        except AttributeError:
             # backward compatibility
             self._var.trace_vdelete('w', self._trace)
             self._trace = self._var.trace('w', self._increment)
@@ -663,6 +663,7 @@ class TickScale(ttk.Frame):
                 self.display_value(self.scale.get())
             if self._tickinterval:
                 self.place_ticks()
-        except Exception:
-            # happens when configure is called during a configuration change
+        except IndexError:
+            # happens when configure is called during a orientation change
+            # because self.ticks is empty
             pass


### PR DESCRIPTION
The goal of this widget is to add to the `ttk.Scale` some options of the `tk.Scale`:
- display ticks (tickinterval option)
- move slider by increments (resolution option)
- display current value of the scale (showvalue option)
- choose the precision of the displayed numbers (digits option)

This widget is even more configurable than the `tk.Scale` since it allows to choose the position of the ticks (tickpos option) and the label displaying the current value (labelpos option).