### PR TITLE
Improve dragging motion for ItemsCanvas

### DIFF
--- a/ttkwidgets/itemscanvas.py
+++ b/ttkwidgets/itemscanvas.py
@@ -109,13 +109,9 @@ class ItemsCanvas(ttk.Frame):
         dx, dy = xc - self.current_coords[0], yc - self.current_coords[1]
         self.current_coords = xc, yc
         self.canvas.move(item, dx, dy)
-        self.canvas.move(rectangle, dx, dy)
         # check whether the new position of the item respects the boundaries
         x, y = self.canvas.coords(item)
-        x = self._max_x if x > self._max_x else x
-        y = self._max_y if y > self._max_y else y
-        x = 0 if x < 0 else x
-        y = 0 if y < 0 else y
+        x, y = max(min(x, self._max_x), 0), max(min(y, self._max_y), 0)
         self.canvas.coords(item, x, y)
         self.canvas.coords(rectangle, self.canvas.bbox(item))
 

--- a/ttkwidgets/itemscanvas.py
+++ b/ttkwidgets/itemscanvas.py
@@ -87,7 +87,7 @@ class ItemsCanvas(ttk.Frame):
         Callback for the release of the left button
         """
         self.config(cursor="")
-        if len(self.canvas.find_withtag("current")) != 0:
+        if len(self.canvas.find_withtag("current")) != 0 and self.current is not None:
             self.canvas.itemconfigure(tk.CURRENT, fill=self.item_colors[self.current][1])
 
     def left_motion(self, event):

--- a/ttkwidgets/itemscanvas.py
+++ b/ttkwidgets/itemscanvas.py
@@ -31,6 +31,7 @@ class ItemsCanvas(ttk.Frame):
         """
         # Setup Frame
         self.current = None
+        self.current_coords = 0, 0
         self.items = {}
         self.item_colors = {}
         # kwarg processing
@@ -69,6 +70,7 @@ class ItemsCanvas(ttk.Frame):
         :param event:
         :return:
         """
+        self.current_coords = self.canvas.canvasx(event.x), self.canvas.canvasy(event.y)
         self.set_current()
         if self.current:
             self.canvas.itemconfigure(self.current, fill=self.item_colors[self.current][1])
@@ -103,7 +105,25 @@ class ItemsCanvas(ttk.Frame):
         rectangle = self.items[item]
         self.config(cursor="exchange")
         self.canvas.itemconfigure(item, fill="blue")
-        x, y = self.canvas.canvasx(event.x), self.canvas.canvasy(event.y)
+        xc, yc = self.canvas.canvasx(event.x), self.canvas.canvasy(event.y)
+        dx, dy = xc - self.current_coords[0], yc - self.current_coords[1]
+        self.current_coords = xc, yc
+#        x = self._max_x if x > self._max_x else x
+#        y = self._max_y if y > self._max_y else y
+#        x = 0 if x < 0 else x
+#        y = 0 if y < 0 else y
+        self.canvas.move(item, dx, dy)
+        self.canvas.move(rectangle, dx, dy)
+#        x1, y1, x2, y2 = self.canvas.coords(rectangle)
+#        if x1 < 0:
+#            x1, x2 = 0, x2 - x1
+#        if y1 < 0:
+#            y1, y2 = 0, y2 - y1
+#        if x2 > self._canvaswidth:
+#            x1, x2 = self._canvaswidth - (x2 - x1), self._canvaswidth
+#        if y2 > self._canvaswidth:
+#            y1, y2 = self._canvaswidth - (y2 - y1), self._canvaswidth
+        x, y = self.canvas.coords(item)
         x = self._max_x if x > self._max_x else x
         y = self._max_y if y > self._max_y else y
         x = 0 if x < 0 else x

--- a/ttkwidgets/itemscanvas.py
+++ b/ttkwidgets/itemscanvas.py
@@ -108,21 +108,8 @@ class ItemsCanvas(ttk.Frame):
         xc, yc = self.canvas.canvasx(event.x), self.canvas.canvasy(event.y)
         dx, dy = xc - self.current_coords[0], yc - self.current_coords[1]
         self.current_coords = xc, yc
-#        x = self._max_x if x > self._max_x else x
-#        y = self._max_y if y > self._max_y else y
-#        x = 0 if x < 0 else x
-#        y = 0 if y < 0 else y
         self.canvas.move(item, dx, dy)
         self.canvas.move(rectangle, dx, dy)
-#        x1, y1, x2, y2 = self.canvas.coords(rectangle)
-#        if x1 < 0:
-#            x1, x2 = 0, x2 - x1
-#        if y1 < 0:
-#            y1, y2 = 0, y2 - y1
-#        if x2 > self._canvaswidth:
-#            x1, x2 = self._canvaswidth - (x2 - x1), self._canvaswidth
-#        if y2 > self._canvaswidth:
-#            y1, y2 = self._canvaswidth - (y2 - y1), self._canvaswidth
         x, y = self.canvas.coords(item)
         x = self._max_x if x > self._max_x else x
         y = self._max_y if y > self._max_y else y


### PR DESCRIPTION
Change dragging so that the mouse stays where it initially was with respect to the borders of the dragged item. It makes the dragging more intuitive than in the previous version, where the item jumped at the start of the dragging because its top left corner went to the mouse position.