### PR TITLE
Add missing examples

### DIFF
--- a/examples/example_askcolor.py
+++ b/examples/example_askcolor.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Juliette Monsel 2017
+# For license see LICENSE
+
+from ttkwidgets.color import askcolor
+try:
+    import Tkinter as tk
+    import ttk
+except ImportError:
+    import tkinter as tk
+    from tkinter import ttk
+from PIL import Image, ImageTk
+
+
+def pick(alpha=False):
+    global im  # to avoid garbage collection of image
+    res = askcolor('sky blue', parent=window, title='Pick a color', alpha=alpha)
+    canvas.delete('image')
+    if res[1] is not None:
+        im = ImageTk.PhotoImage(Image.new('RGBA', (100, 100), res[1]), master=window)
+        canvas.create_image(60, 60, image=im, tags='image', anchor='center')
+    print(res)
+
+
+window = tk.Tk()
+canvas = tk.Canvas(window, width=120, height=120)
+canvas.create_text(60, 60, text='Background', anchor='center')
+canvas.pack()
+ttk.Button(window, text="Pick a color (No alpha channel)", command=pick).pack(fill='x')
+ttk.Button(window, text="Pick a color (With alpha channel)", command=lambda: pick(True)).pack(fill='x')
+window.mainloop()

--- a/examples/example_askcolor.py
+++ b/examples/example_askcolor.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) Juliette Monsel 2017
+# Copyright (c) Juliette Monsel 2018
 # For license see LICENSE
 
 from ttkwidgets.color import askcolor

--- a/examples/example_askfont.py
+++ b/examples/example_askfont.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) Juliette Monsel 2017
+# Copyright (c) Juliette Monsel 2018
 # For license see LICENSE
 
 from ttkwidgets.font import askfont

--- a/examples/example_askfont.py
+++ b/examples/example_askfont.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Juliette Monsel 2017
+# For license see LICENSE
+
+from ttkwidgets.font import askfont
+try:
+    import Tkinter as tk
+    import ttk
+except ImportError:
+    import tkinter as tk
+    from tkinter import ttk
+
+def font():
+    res = askfont()
+    if res[0] is not None:
+        label.configure(font=res[0])
+    print(res)
+
+window = tk.Tk()
+label = ttk.Label(window, text='Sample text rendered in the chosen font.')
+label.pack(padx=10, pady=10)
+ttk.Button(window, text="Pick a font", command=font).pack()
+window.mainloop()

--- a/examples/example_autocompletecombobox.py
+++ b/examples/example_autocompletecombobox.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Juliette Monsel 2018
+# For license see LICENSE
+
+from ttkwidgets.autocomplete import AutocompleteCombobox
+try:
+    import Tkinter as tk
+except ImportError:
+    import tkinter as tk
+
+window = tk.Tk()
+tk.Label(window, text="Combobox with autocompletion for the Tk instance's methods:").pack(side='left')
+entry = AutocompleteCombobox(window, width=20, completevalues=dir(window))
+entry.pack(side='right')
+window.mainloop()

--- a/examples/example_autocompleteentry.py
+++ b/examples/example_autocompleteentry.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Juliette Monsel 2018
+# For license see LICENSE
+
+from ttkwidgets.autocomplete import AutocompleteEntry
+try:
+    import Tkinter as tk
+except ImportError:
+    import tkinter as tk
+
+window = tk.Tk()
+tk.Label(window, text="Entry with autocompletion for the Tk instance's methods:").pack(side='left')
+entry = AutocompleteEntry(window, width=20, completevalues=dir(window))
+entry.pack(side='right')
+window.mainloop()

--- a/examples/example_autohidescrollbar.py
+++ b/examples/example_autohidescrollbar.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Juliette Monsel 2018
+# For license see LICENSE
+
+from ttkwidgets import AutoHideScrollbar
+try:
+    import Tkinter as tk
+except ImportError:
+    import tkinter as tk
+
+window = tk.Tk()
+listbox = tk.Listbox(window, height=5)
+scrollbar = AutoHideScrollbar(window, command=listbox.yview)
+listbox.configure(yscrollcommand=scrollbar.set)
+
+for i in range(10):
+    listbox.insert('end', 'item %i' % i)
+
+tk.Label(window, text="Increase the window's height\nto make the scrollbar vanish.").pack(side='top', padx=4, pady=4)
+scrollbar.pack(side='right', fill='y')
+listbox.pack(side='left', fill='both', expand=True)
+
+window.mainloop()

--- a/examples/example_calendar.py
+++ b/examples/example_calendar.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Juliette Monsel 2018
+# For license see LICENSE
+
+from ttkwidgets import Calendar
+try:
+    import Tkinter as tk
+except ImportError:
+    import tkinter as tk
+
+def validate():
+    sel = calendar.selection
+    if sel is not None:
+        label.configure(text='Selected date: %s' % sel.strftime('%x'))
+
+window = tk.Tk()
+calendar = Calendar(window, year=2015, month=3, selectforeground='white',
+                    selectbackground='red')
+calendar.pack()
+
+tk.Button(window, text='Select', command=validate).pack()
+label = tk.Label(window, text='Selected date:')
+label.pack()
+window.mainloop()

--- a/examples/example_fontselectframe.py
+++ b/examples/example_fontselectframe.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Juliette Monsel 2018
+# For license see LICENSE
+
+from ttkwidgets.font import FontSelectFrame
+try:
+    import Tkinter as tk
+    import ttk
+except ImportError:
+    import tkinter as tk
+    from tkinter import ttk
+
+def update_preview(font_tuple):
+    print(font_tuple)
+    font = font_selection.font[0]
+    if font is not None:
+        label.configure(font=font)
+
+window = tk.Tk()
+label = ttk.Label(window, text='Sample text rendered in the chosen font.')
+label.pack(padx=10, pady=10)
+font_selection = FontSelectFrame(window, callback=update_preview)
+font_selection.pack()
+window.mainloop()

--- a/examples/example_linklabel.py
+++ b/examples/example_linklabel.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) RedFantom 2017
+# Copyright (c) Juliette Monsel 2018
+# For license see LICENSE
+
+from ttkwidgets import LinkLabel
+try:
+    import Tkinter as tk
+except ImportError:
+    import tkinter as tk
+
+window = tk.Tk()
+LinkLabel(window, text="ttkwidgets repository",
+          link="https://github.com/RedFantom/ttkwidgets",
+          normal_color='royal blue',
+          hover_color='blue',
+          clicked_color='purple').pack()
+window.mainloop()

--- a/examples/example_scaleentry.py
+++ b/examples/example_scaleentry.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Juliette Monsel 2018
+# For license see LICENSE
+
+from ttkwidgets import ScaleEntry
+try:
+    import Tkinter as tk
+except ImportError:
+    import tkinter as tk
+
+
+window = tk.Tk()
+scaleentry = ScaleEntry(window, scalewidth=200, entrywidth=3, from_=0, to=20)
+scaleentry.config_entry(justify='center')
+scaleentry.pack()
+window.mainloop()

--- a/examples/example_scrolledframe.py
+++ b/examples/example_scrolledframe.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Juliette Monsel 2018
+# For license see LICENSE
+
+from ttkwidgets.frames import ScrolledFrame
+try:
+    import Tkinter as tk
+    import ttk
+except ImportError:
+    import tkinter as tk
+    from tkinter import ttk
+
+window = tk.Tk()
+frame = ScrolledFrame(window, compound=tk.RIGHT, canvasheight=200)
+frame.pack(fill='both', expand=True)
+
+for i in range(20):
+    ttk.Label(frame.interior, text='Label %i' % i).pack()
+window.mainloop()

--- a/examples/example_scrolledlistbox.py
+++ b/examples/example_scrolledlistbox.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) RedFantom 2017
+# For license see LICENSE
+
+from ttkwidgets import ScrolledListbox
+try:
+    import Tkinter as tk
+except ImportError:
+    import tkinter as tk
+
+window = tk.Tk()
+listbox = ScrolledListbox(window, height=5)
+
+for i in range(10):
+    listbox.listbox.insert('end', 'item {}'.format(i))
+
+listbox.pack(fill='both', expand=True)
+window.mainloop()

--- a/examples/example_scrolledlistbox.py
+++ b/examples/example_scrolledlistbox.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) RedFantom 2017
+# Copyright (c) Juliette Monsel 2018
 # For license see LICENSE
 
 from ttkwidgets import ScrolledListbox

--- a/ttkwidgets/frames/scrolledframe.py
+++ b/ttkwidgets/frames/scrolledframe.py
@@ -31,6 +31,9 @@ class ScrolledFrame(ttk.Frame):
         :param kwargs: passed on to Frame.__init__
         """
         ttk.Frame.__init__(self, master, **kwargs)
+        self.rowconfigure(0, weight=1)
+        self.columnconfigure(1, weight=1)
+        
         self._scrollbar = ttk.Scrollbar(self, orient=tk.VERTICAL)
         self._canvas = tk.Canvas(self, borderwidth=canvasborder, highlightthickness=0,
                                  yscrollcommand=self._scrollbar.set, width=canvaswidth, height=canvasheight)
@@ -50,7 +53,6 @@ class ScrolledFrame(ttk.Frame):
         """
         scrollbar_column = 0 if self.__compound is tk.LEFT else 2
         self._canvas.grid(row=0, column=1, sticky="nswe")
-        self.interior.grid(row=0, column=1, sticky="nswe")
         self._scrollbar.grid(row=0, column=scrollbar_column, sticky="ns")
 
     def __configure_interior(self, *args):

--- a/ttkwidgets/linklabel.py
+++ b/ttkwidgets/linklabel.py
@@ -115,8 +115,3 @@ class LinkLabel(ttk.Label):
         keys.extend(["link", "normal_color", "hover_color", "clicked_color"])
         return keys
 
-
-if __name__ == '__main__':
-    window = tk.Tk()
-    LinkLabel(window, text="Label").pack()
-    window.mainloop()

--- a/ttkwidgets/scrolledlistbox.py
+++ b/ttkwidgets/scrolledlistbox.py
@@ -24,6 +24,8 @@ class ScrolledListbox(ttk.Frame):
         :param kwargs: keyword arguments passed on to Listbox initializer
         """
         ttk.Frame.__init__(self, master)
+        self.columnconfigure(1, weight=1)
+        self.rowconfigure(0, weight=1)
         self.listbox = tk.Listbox(self, **kwargs)
         self.scrollbar = ttk.Scrollbar(self, orient=tk.VERTICAL, command=self.listbox.yview)
         self.config_listbox(yscrollcommand=self.scrollbar.set)


### PR DESCRIPTION
Add examples for the following widgets / functions:
- `AutoHideScrollbar`
- `Calendar`
- `LinkLabel`
- `ScaleEntry`
- `ScrolledListbox`
- `autocomplete` package:
    - `AutocompleteCombobox`
    - `AutocompleteEntry`
- `color` package:
    - `askcolor()`
- `font` package:
    - `askfont()`
    - `FontSelectFrame`
- `frames` package:
    - `ScrolledFrame`