### PR TITLE
Add Installation section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ A collection of widgets for Tkinter's ttk extensions by various authors.
 
         pip install ttkwidgets
 
-- Ubuntu: ttkwidgets is available in the PPA [ppa:j-4321-i/ttkwidgets](https://launchpad.net/~j-4321-i/+archive/ubuntu/ttkwidgets)
+- Ubuntu: ttkwidgets is available in the PPA [ppa:j-4321-i/ttkwidgets](https://launchpad.net/~j-4321-i/+archive/ubuntu/ttkwidgets).
 
         sudo add-apt-repository ppa:j-4321-i/ttkwidgets
         sudo apt-get update
         sudo apt-get install python(3)-ttkwidgets
 
-- Archlinux: ttkwidgets is available in [AUR](https://aur.archlinux.org/packages/python-ttkwidgets/>).
+- Archlinux: ttkwidgets is available in [AUR](https://aur.archlinux.org/packages/python-ttkwidgets).
 
 ## Contributing
 If you have created a widget that you think is worth adding, then feel free to fork the repository and create a Pull

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![PyPI version](https://badge.fury.io/py/ttkwidgets.svg)](https://badge.fury.io/py/ttkwidgets)
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
 
-A collection of widgets for Tkinter's ttk extensions by various authors
+A collection of widgets for Tkinter's ttk extensions by various authors.
 
 ## License
     ttkwidgets: A collection of widgets for Tkinter's ttk extensions by various authors 
@@ -27,11 +27,24 @@ A collection of widgets for Tkinter's ttk extensions by various authors
     
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
-    
+
+## Installation
+- With pip:
+
+        pip install ttkwidgets
+
+- Ubuntu: ttkwidgets is available in the PPA [ppa:j-4321-i/ttkwidgets](https://launchpad.net/~j-4321-i/+archive/ubuntu/ttkwidgets)
+
+        sudo add-apt-repository ppa:j-4321-i/ttkwidgets
+        sudo apt-get update
+        sudo apt-get install python(3)-ttkwidgets
+
+- Archlinux: ttkwidgets is available in [AUR](https://aur.archlinux.org/packages/python-ttkwidgets/>).
+
 ## Contributing
 If you have created a widget that you think is worth adding, then feel free to fork the repository and create a Pull
 Request when you've added the widget to your copy of the repository. You will be credited for your work, and you can add
-headers to your files. You will also be added to the `AUTHORS.md`-file.
+headers to your files. You will also be added to the [AUTHORS.md](AUTHORS.md) file.
 
 ## Issues
 If you find any bugs or have any ideas, feel free to open an issue here in the repository, and it will be looked at.

--- a/ttkwidgets/checkboxtreeview.py
+++ b/ttkwidgets/checkboxtreeview.py
@@ -16,9 +16,9 @@ import os
 from PIL import Image, ImageTk
 from ttkwidgets.utilities import get_assets_directory
 
-IM_CHECKED = os.path.join(get_assets_directory(), "checked.png")
-IM_UNCHECKED = os.path.join(get_assets_directory(), "unchecked.png")
-IM_TRISTATE = os.path.join(get_assets_directory(), "tristate.png")
+IM_CHECKED = os.path.join(get_assets_directory(), "checked.png")      # These three checkbox icons were isolated from
+IM_UNCHECKED = os.path.join(get_assets_directory(), "unchecked.png")  # Checkbox States.svg (https://commons.wikimedia.org/wiki/File:Checkbox_States.svg?uselang=en)
+IM_TRISTATE = os.path.join(get_assets_directory(), "tristate.png")    # by Marekich [CC BY-SA 3.0  (https://creativecommons.org/licenses/by-sa/3.0)]
 
 
 class CheckboxTreeview(ttk.Treeview):


### PR DESCRIPTION
ttkwidgets is now available as a .deb in the ppa:j-4321-i/ttkwidgets hosted on my launchpad account. I have therefore added an *Installation* section to README.md to list the available methods of installation.