### PR TITLE
Use AutoHideScrollbar in scrollable widgets

### DIFF
--- a/tests/test_debugwindow.py
+++ b/tests/test_debugwindow.py
@@ -19,6 +19,11 @@ class TestDebugWindow(BaseWidgetTest):
     def test_debugwindow_init(self):
         debug = DebugWindow(self.window)
         self.window.update()
+        self.assertFalse(debug.scroll.winfo_ismapped())
+        debug.destroy()
+        debug = DebugWindow(self.window, autohidescrollbar=False)
+        self.window.update()
+        self.assertTrue(debug.scroll.winfo_ismapped())
 
     def test_debugwindow_print(self):
         debug = DebugWindow(self.window)

--- a/tests/test_scrolledframe.py
+++ b/tests/test_scrolledframe.py
@@ -13,6 +13,13 @@ class TestScrolledFrame(BaseWidgetTest):
         frame = ScrolledFrame(self.window)
         frame.pack()
         self.window.update()
+        self.assertFalse(frame._scrollbar.winfo_ismapped())
+        
+        frame.destroy()
+        frame = ScrolledFrame(self.window, autohidescrollbar=False)
+        frame.pack()
+        self.window.update()
+        self.assertTrue(frame._scrollbar.winfo_ismapped())
 
     def test_scrollframe_methods(self):
         frame = ScrolledFrame(self.window)

--- a/tests/test_scrolledlistbox.py
+++ b/tests/test_scrolledlistbox.py
@@ -14,3 +14,10 @@ class TestScrolledListBox(BaseWidgetTest):
         listbox = ScrolledListbox(self.window, height=10, width=10, compound=tk.LEFT)
         listbox.pack()
         self.window.update()
+        self.assertFalse(listbox.scrollbar.winfo_ismapped())
+        listbox.destroy()
+        
+        listbox = ScrolledListbox(self.window, height=20, width=10, compound=tk.RIGHT, autohidescrollbar=False)
+        listbox.pack()
+        self.window.update()
+        self.assertTrue(listbox.scrollbar.winfo_ismapped())

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -15,6 +15,7 @@ class TestTimeLine(BaseWidgetTest):
     def test_kwargs(self):
         alternates = {
             "background": "black",
+            "autohidescrollbars": True,
             "marker_foreground": "white",
             "menu": tk.Menu(),
             "categories": ("category_a", "category_b"),

--- a/ttkwidgets/debugwindow.py
+++ b/ttkwidgets/debugwindow.py
@@ -19,7 +19,8 @@ class DebugWindow(tk.Toplevel):
     """
     A Toplevel that shows sys.stdout and sys.stderr for Tkinter applications
     """
-    def __init__(self, master=None, title="Debug window", stdout=True, stderr=False, width=70, **kwargs):
+    def __init__(self, master=None, title="Debug window", stdout=True, 
+                 stderr=False, width=70, autohidescrollbars=True, **kwargs):
         self._width = width
         tk.Toplevel.__init__(self, master, **kwargs)
         self.columnconfigure(0, weight=1)
@@ -39,7 +40,10 @@ class DebugWindow(tk.Toplevel):
         self.filemenu.add_command(label="Exit", command=self.quit)
         self.menu.add_cascade(label="File", menu=self.filemenu)
         self.text = tk.Text(self, width=width, wrap=tk.WORD)
-        self.scroll = AutoHideScrollbar(self, orient=tk.VERTICAL, command=self.text.yview)
+        if autohidescrollbars:
+            self.scroll = AutoHideScrollbar(self, orient=tk.VERTICAL, command=self.text.yview)
+        else:
+            self.scroll = ttk.Scrollbar(self, orient=tk.VERTICAL, command=self.text.yview)
         self.text.config(yscrollcommand=self.scroll.set)
         self.text.bind("<Key>", lambda e: "break")
         self._grid_widgets()

--- a/ttkwidgets/debugwindow.py
+++ b/ttkwidgets/debugwindow.py
@@ -12,6 +12,7 @@ except ImportError:
     from tkinter import ttk
     import tkinter.filedialog as fd
 import sys
+from ttkwidgets import AutoHideScrollbar
 
 
 class DebugWindow(tk.Toplevel):
@@ -21,6 +22,8 @@ class DebugWindow(tk.Toplevel):
     def __init__(self, master=None, title="Debug window", stdout=True, stderr=False, width=70, **kwargs):
         self._width = width
         tk.Toplevel.__init__(self, master, **kwargs)
+        self.columnconfigure(0, weight=1)
+        self.rowconfigure(0, weight=1)
         self.protocol("WM_DELETE_WINDOW", self.quit)
         self.wm_title(title)
         self._oldstdout = sys.stdout
@@ -36,7 +39,7 @@ class DebugWindow(tk.Toplevel):
         self.filemenu.add_command(label="Exit", command=self.quit)
         self.menu.add_cascade(label="File", menu=self.filemenu)
         self.text = tk.Text(self, width=width, wrap=tk.WORD)
-        self.scroll = ttk.Scrollbar(self, orient=tk.VERTICAL, command=self.text.yview)
+        self.scroll = AutoHideScrollbar(self, orient=tk.VERTICAL, command=self.text.yview)
         self.text.config(yscrollcommand=self.scroll.set)
         self.text.bind("<Key>", lambda e: "break")
         self._grid_widgets()
@@ -49,7 +52,7 @@ class DebugWindow(tk.Toplevel):
             f.write(self.text.get("1.0", tk.END))
 
     def _grid_widgets(self):
-        self.text.grid(row=0, column=0)
+        self.text.grid(row=0, column=0, sticky="nsew")
         self.scroll.grid(row=0, column=1, sticky="ns")
 
     def write(self, line):

--- a/ttkwidgets/debugwindow.py
+++ b/ttkwidgets/debugwindow.py
@@ -20,7 +20,7 @@ class DebugWindow(tk.Toplevel):
     A Toplevel that shows sys.stdout and sys.stderr for Tkinter applications
     """
     def __init__(self, master=None, title="Debug window", stdout=True, 
-                 stderr=False, width=70, autohidescrollbars=True, **kwargs):
+                 stderr=False, width=70, autohidescrollbar=True, **kwargs):
         self._width = width
         tk.Toplevel.__init__(self, master, **kwargs)
         self.columnconfigure(0, weight=1)
@@ -40,7 +40,7 @@ class DebugWindow(tk.Toplevel):
         self.filemenu.add_command(label="Exit", command=self.quit)
         self.menu.add_cascade(label="File", menu=self.filemenu)
         self.text = tk.Text(self, width=width, wrap=tk.WORD)
-        if autohidescrollbars:
+        if autohidescrollbar:
             self.scroll = AutoHideScrollbar(self, orient=tk.VERTICAL, command=self.text.yview)
         else:
             self.scroll = ttk.Scrollbar(self, orient=tk.VERTICAL, command=self.text.yview)

--- a/ttkwidgets/frames/scrolledframe.py
+++ b/ttkwidgets/frames/scrolledframe.py
@@ -22,20 +22,24 @@ class ScrolledFrame(ttk.Frame):
     Widgets can be placed in instance.interior attribute Frame with any geometry manager
     """
 
-    def __init__(self, master=None, compound=tk.RIGHT, canvasheight=400, canvaswidth=400, canvasborder=0, **kwargs):
+    def __init__(self, master=None, compound=tk.RIGHT, canvasheight=400, 
+                 canvaswidth=400, canvasborder=0, autohidescrollbar=True, **kwargs):
         """
         :param master: master widget
         :param compound: side the scrollbar should be on
         :param canvasheight: hight of the internal canvas
         :param canvaswidth: width of the internal canvas
         :param canvasborder: border width of the internal canvas
+        :param autohidescrollbar: whether to use an AutoHideScrollbar or a ttk.Scrollbar
         :param kwargs: passed on to Frame.__init__
         """
         ttk.Frame.__init__(self, master, **kwargs)
         self.rowconfigure(0, weight=1)
         self.columnconfigure(1, weight=1)
-        
-        self._scrollbar = AutoHideScrollbar(self, orient=tk.VERTICAL)
+        if autohidescrollbar:
+            self._scrollbar = AutoHideScrollbar(self, orient=tk.VERTICAL)
+        else:
+            self._scrollbar = ttk.Scrollbar(self, orient=tk.VERTICAL)
         self._canvas = tk.Canvas(self, borderwidth=canvasborder, highlightthickness=0,
                                  yscrollcommand=self._scrollbar.set, width=canvaswidth, height=canvasheight)
         self.__compound = compound

--- a/ttkwidgets/frames/scrolledframe.py
+++ b/ttkwidgets/frames/scrolledframe.py
@@ -12,6 +12,7 @@ try:
 except ImportError:
     import tkinter as tk
     from tkinter import ttk
+from ttkwidgets import AutoHideScrollbar
 
 
 class ScrolledFrame(ttk.Frame):
@@ -34,7 +35,7 @@ class ScrolledFrame(ttk.Frame):
         self.rowconfigure(0, weight=1)
         self.columnconfigure(1, weight=1)
         
-        self._scrollbar = ttk.Scrollbar(self, orient=tk.VERTICAL)
+        self._scrollbar = AutoHideScrollbar(self, orient=tk.VERTICAL)
         self._canvas = tk.Canvas(self, borderwidth=canvasborder, highlightthickness=0,
                                  yscrollcommand=self._scrollbar.set, width=canvaswidth, height=canvasheight)
         self.__compound = compound

--- a/ttkwidgets/scrolledlistbox.py
+++ b/ttkwidgets/scrolledlistbox.py
@@ -9,6 +9,7 @@ try:
 except ImportError:
     import tkinter as tk
     from tkinter import ttk
+from ttkwidgets import AutoHideScrollbar
 
 
 class ScrolledListbox(ttk.Frame):
@@ -27,7 +28,7 @@ class ScrolledListbox(ttk.Frame):
         self.columnconfigure(1, weight=1)
         self.rowconfigure(0, weight=1)
         self.listbox = tk.Listbox(self, **kwargs)
-        self.scrollbar = ttk.Scrollbar(self, orient=tk.VERTICAL, command=self.listbox.yview)
+        self.scrollbar = AutoHideScrollbar(self, orient=tk.VERTICAL, command=self.listbox.yview)
         self.config_listbox(yscrollcommand=self.scrollbar.set)
         if compound is not tk.LEFT and compound is not tk.RIGHT:
             raise ValueError("Invalid compound value passed: {0}".format(compound))

--- a/ttkwidgets/scrolledlistbox.py
+++ b/ttkwidgets/scrolledlistbox.py
@@ -16,19 +16,21 @@ class ScrolledListbox(ttk.Frame):
     """
     Simple Listbox with an added scrollbar
     """
-    def __init__(self, master=None, compound=tk.RIGHT, **kwargs):
+    def __init__(self, master=None, compound=tk.RIGHT, autohidescrollbar=True, **kwargs):
         """
         :param master: master widget
         :param compound: side for the Scrollbar to be on (tk.LEFT or tk.RIGHT)
-        :param listheight: height of the Listbox in items
-        :param listwidth: width of the Listbox in characters
+        :param autohidescrollbar: whether to use an AutoHideScrollbar or a ttk.Scrollbar
         :param kwargs: keyword arguments passed on to Listbox initializer
         """
         ttk.Frame.__init__(self, master)
         self.columnconfigure(1, weight=1)
         self.rowconfigure(0, weight=1)
         self.listbox = tk.Listbox(self, **kwargs)
-        self.scrollbar = AutoHideScrollbar(self, orient=tk.VERTICAL, command=self.listbox.yview)
+        if autohidescrollbar:
+            self.scrollbar = AutoHideScrollbar(self, orient=tk.VERTICAL, command=self.listbox.yview)
+        else:
+            self.scrollbar = ttk.Scrollbar(self, orient=tk.VERTICAL, command=self.listbox.yview)
         self.config_listbox(yscrollcommand=self.scrollbar.set)
         if compound is not tk.LEFT and compound is not tk.RIGHT:
             raise ValueError("Invalid compound value passed: {0}".format(compound))

--- a/ttkwidgets/timeline.py
+++ b/ttkwidgets/timeline.py
@@ -11,6 +11,7 @@ except ImportError:
     from tkinter import ttk
 from ttkwidgets.utilities import open_icon
 from collections import OrderedDict
+from ttkwidgets import AutoHideScrollbar
 
 
 class TimeLine(ttk.Frame):
@@ -189,8 +190,8 @@ class TimeLine(ttk.Frame):
         self._canvas_scroll = tk.Canvas(self, background=self._background, width=self._width, height=self._height)
         self._timeline = tk.Canvas(self._canvas_scroll, background=self._background, borderwidth=0)
         self._timeline_id = self._canvas_scroll.create_window(0, 0, window=self._timeline, anchor=tk.NW)
-        self._scrollbar_timeline = ttk.Scrollbar(self, command=self.set_scroll, orient=tk.HORIZONTAL)
-        self._scrollbar_vertical = ttk.Scrollbar(self, command=self.set_scroll_v, orient=tk.VERTICAL)
+        self._scrollbar_timeline = AutoHideScrollbar(self, command=self.set_scroll, orient=tk.HORIZONTAL)
+        self._scrollbar_vertical = AutoHideScrollbar(self, command=self.set_scroll_v, orient=tk.VERTICAL)
         self._canvas_scroll.config(xscrollcommand=self._scrollbar_timeline.set,
                                    yscrollcommand=self._scrollbar_vertical.set)
         self._canvas_categories.config(yscrollcommand=self._scrollbar_vertical.set)

--- a/ttkwidgets/timeline.py
+++ b/ttkwidgets/timeline.py
@@ -83,6 +83,7 @@ class TimeLine(ttk.Frame):
                 marker and a tick before the marker is snapped into place
             * tk.Menu menu: Menu to show when a right-click is performed somewhere          None
                 on the timeline without a marker being active
+            * bool autohidescrollbars: Use AutoHideScrollbar instead of ttk.Scrollbar       False
             Marker options:
             * tuple marker_font: font tuple to specify the default font for the             ("default", 10)
                 markers
@@ -127,6 +128,7 @@ class TimeLine(ttk.Frame):
         self._extend = kwargs.pop("extend", False)
         self._snap_margin = kwargs.pop("snap_margin", 10)
         self._menu = kwargs.pop("menu", None)
+        self._autohidescrollbars = kwargs.pop("autohidescrollbars", False)
         kwargs["style"] = self._style
         self._marker_font = kwargs.pop("marker_font", ("default", 10))
         self._marker_background = kwargs.pop("marker_background", "lightblue")
@@ -190,8 +192,12 @@ class TimeLine(ttk.Frame):
         self._canvas_scroll = tk.Canvas(self, background=self._background, width=self._width, height=self._height)
         self._timeline = tk.Canvas(self._canvas_scroll, background=self._background, borderwidth=0)
         self._timeline_id = self._canvas_scroll.create_window(0, 0, window=self._timeline, anchor=tk.NW)
-        self._scrollbar_timeline = AutoHideScrollbar(self, command=self.set_scroll, orient=tk.HORIZONTAL)
-        self._scrollbar_vertical = AutoHideScrollbar(self, command=self.set_scroll_v, orient=tk.VERTICAL)
+        if self._autohidescrollbars:
+            self._scrollbar_timeline = AutoHideScrollbar(self, command=self.set_scroll, orient=tk.HORIZONTAL)
+            self._scrollbar_vertical = AutoHideScrollbar(self, command=self.set_scroll_v, orient=tk.VERTICAL)
+        else:
+            self._scrollbar_timeline = ttk.Scrollbar(self, command=self.set_scroll, orient=tk.HORIZONTAL)
+            self._scrollbar_vertical = ttk.Scrollbar(self, command=self.set_scroll_v, orient=tk.VERTICAL)
         self._canvas_scroll.config(xscrollcommand=self._scrollbar_timeline.set,
                                    yscrollcommand=self._scrollbar_vertical.set)
         self._canvas_categories.config(yscrollcommand=self._scrollbar_vertical.set)
@@ -993,7 +999,7 @@ class TimeLine(ttk.Frame):
         return [
             # TimeLine options
             "width", "height", "extend", "start", "finish", "resolution", "tick_resolution", "unit", "zoom_enabled",
-            "categories", "background", "style", "zoom_factors", "zoom_default", "extend", "menu", "snap_margin",
+            "categories", "background", "style", "zoom_factors", "zoom_default", "extend", "menu", "autohidescrollbars", "snap_margin",
             # Marker options
             "marker_font", "marker_background", "marker_foreground", "marker_outline", "marker_border", "marker_move",
             "marker_change_category", "marker_allow_overlap", "marker_snap_to_ticks"
@@ -1016,9 +1022,24 @@ class TimeLine(ttk.Frame):
         """
         kwargs.update(cnf)
         TimeLine.check_kwargs(kwargs)
+        scrollbars = 'autohidescrollbars' in kwargs
         for option in self.options:
             attribute = "_" + option
             setattr(self, attribute, kwargs.pop(option, getattr(self, attribute)))
+        if scrollbars:
+            self._scrollbar_timeline.destroy()
+            self._scrollbar_vertical.destroy()
+            if self._autohidescrollbars:
+                self._scrollbar_timeline = AutoHideScrollbar(self, command=self.set_scroll, orient=tk.HORIZONTAL)
+                self._scrollbar_vertical = AutoHideScrollbar(self, command=self.set_scroll_v, orient=tk.VERTICAL)
+            else:
+                self._scrollbar_timeline = ttk.Scrollbar(self, command=self.set_scroll, orient=tk.HORIZONTAL)
+                self._scrollbar_vertical = ttk.Scrollbar(self, command=self.set_scroll_v, orient=tk.VERTICAL)
+            self._canvas_scroll.config(xscrollcommand=self._scrollbar_timeline.set,
+                                       yscrollcommand=self._scrollbar_vertical.set)
+            self._canvas_categories.config(yscrollcommand=self._scrollbar_vertical.set)
+            self._scrollbar_timeline.grid(column=1, row=2, padx=(0, 5), pady=(0, 5), sticky="we")
+            self._scrollbar_vertical.grid(column=2, row=0, pady=5, padx=(0, 5), sticky="ns")
         ttk.Frame.configure(self, **kwargs)
         self.generate_timeline_contents()
 
@@ -1139,6 +1160,9 @@ class TimeLine(ttk.Frame):
         menu = kwargs.get("menu", None)
         if menu is not None and not isinstance(menu, tk.Menu):
             raise TypeError("menu argument is not a tk.Menu widget")
+        autohidescrollbars = kwargs.get("autohidescrollbars", False)
+        if not isinstance(autohidescrollbars, bool):
+            raise TypeError("autohidescrollbars argument is not of bool type")
         # marker options
         marker_font = kwargs.get("marker_font", ("default", 10))
         marker_background = kwargs.get("marker_background", "lightblue")

--- a/ttkwidgets/timeline.py
+++ b/ttkwidgets/timeline.py
@@ -1056,7 +1056,7 @@ class TimeLine(ttk.Frame):
         return self.cget(item)
 
     def __setitem__(self, key, value):
-        return self.configure(key=value)
+        return self.configure(**{key: value})
 
     def itemconfigure(self, iid, rectangle_options, text_options):
         """


### PR DESCRIPTION
I propose to replace the `ttk.Scrollbar` by `AutoHideScrollbar` in the widgets :
- `DebugWindow`
- `ScrolledFrame`
- `ScrolledListbox`
- `TimeLine`