### PR TITLE
Fix Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ virtualenv:
     system_site_packages: true
 before_install:
   - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+  - sudo systemctl start xvfb
   - sleep 3
 install:
   - sudo apt-get install python-tk


### PR DESCRIPTION
The ubuntu environment used for the tests by Travis CI has been updated so
`sh -e /etc/init.d/xvfb start` no longer works and need to be replaced by
`sudo systemctl start xvfb`.
