### PR TITLE
Small improvements of the color submodule

### DIFF
--- a/ttkwidgets/color/colorpicker.py
+++ b/ttkwidgets/color/colorpicker.py
@@ -322,6 +322,7 @@ class ColorPicker(tk.Toplevel):
         self.hexa.bind("<Return>", self._update_color_hexa)
         self.hexa.bind("<Control-a>", self._select_all_entry)
 
+        self.hexa.focus_set()
         self.wait_visibility()
         self.lift()
         self.grab_set()

--- a/ttkwidgets/color/colorpicker.py
+++ b/ttkwidgets/color/colorpicker.py
@@ -46,9 +46,12 @@ FR = {"Red": "Rouge", "Green": "Vert", "Blue": "Bleu",
       "Cancel": "Annuler", "Color Chooser": "Sélecteur de couleur",
       "Alpha": "Alpha"}
 
-if getdefaultlocale()[0][:2] == 'fr':
-    TR = FR
-else:
+try:
+    if getdefaultlocale()[0][:2] == 'fr':
+        TR = FR
+    else:
+        TR = EN
+except ValueError:
     TR = EN
 
 

--- a/ttkwidgets/color/colorpicker.py
+++ b/ttkwidgets/color/colorpicker.py
@@ -302,17 +302,25 @@ class ColorPicker(tk.Toplevel):
         s_red.bind('<Return>', self._update_color_rgb)
         s_green.bind('<Return>', self._update_color_rgb)
         s_blue.bind('<Return>', self._update_color_rgb)
+        s_red.bind('<Control-a>', self._select_all_spinbox)
+        s_green.bind('<Control-a>', self._select_all_spinbox)
+        s_blue.bind('<Control-a>', self._select_all_spinbox)
         s_h.bind('<FocusOut>', self._update_color_hsv)
         s_s.bind('<FocusOut>', self._update_color_hsv)
         s_v.bind('<FocusOut>', self._update_color_hsv)
         s_h.bind('<Return>', self._update_color_hsv)
         s_s.bind('<Return>', self._update_color_hsv)
         s_v.bind('<Return>', self._update_color_hsv)
+        s_h.bind('<Control-a>', self._select_all_spinbox)
+        s_s.bind('<Control-a>', self._select_all_spinbox)
+        s_v.bind('<Control-a>', self._select_all_spinbox)
         if alpha:
             s_alpha.bind('<Return>', self._update_alpha)
             s_alpha.bind('<FocusOut>', self._update_alpha)
+            s_alpha.bind('<Control-a>', self._select_all_spinbox)
         self.hexa.bind("<FocusOut>", self._update_color_hexa)
         self.hexa.bind("<Return>", self._update_color_hexa)
+        self.hexa.bind("<Control-a>", self._select_all_entry)
 
         self.wait_visibility()
         self.lift()
@@ -325,6 +333,18 @@ class ColorPicker(tk.Toplevel):
         :return: selected color as a (RGB, HSV, HEX) tuple or ""
         """
         return self.color
+
+    @staticmethod
+    def _select_all_spinbox(event):
+        """Select all entry content."""
+        event.widget.selection('range', 0, 'end')
+        return "break"
+
+    @staticmethod
+    def _select_all_entry(event):
+        """Select all entry content."""
+        event.widget.selection_range(0, 'end')
+        return "break"
 
     def _unfocus(self, event):
         """Unfocus palette items when click on bar or square."""

--- a/ttkwidgets/color/gradientbar.py
+++ b/ttkwidgets/color/gradientbar.py
@@ -92,7 +92,7 @@ class GradientBar(tk.Canvas):
             line.append(rgb_to_hexa(*hue2col(float(i) / width * 360)))
         line = "{" + " ".join(line) + "}"
         self.gradient.put(" ".join([line for j in range(height)]))
-        self.create_image(0, 0, anchor="nw", tags="gardient",
+        self.create_image(0, 0, anchor="nw", tags="gradient",
                           image=self.gradient)
         self.lower("gradient")
 

--- a/ttkwidgets/color/spinbox.py
+++ b/ttkwidgets/color/spinbox.py
@@ -43,19 +43,25 @@ class Spinbox(tk.Spinbox):
                                relief=kwargs.get("relief", "sunken"),
                                borderwidth=1)
         self.style.configure("%s.spinbox.TFrame" % self.frame,
-                             background="white")
+                             background=self.style.lookup("TSpinbox",
+                                                          "fieldbackground",
+                                                          default='white'))
         self.frame.configure(style="%s.spinbox.TFrame" % self.frame)
         kwargs["relief"] = "flat"
         kwargs["highlightthickness"] = 0
-        kwargs["selectbackground"] = self.style.lookup("TEntry",
+        kwargs["selectbackground"] = self.style.lookup("TSpinbox",
                                                        "selectbackground",
                                                        ("focus",))
-        kwargs["selectbackground"] = self.style.lookup("TEntry",
-                                                       "selectbackground",
-                                                       ("focus",))
-        kwargs["selectforeground"] = self.style.lookup("TEntry",
+        kwargs["selectforeground"] = self.style.lookup("TSpinbox",
                                                        "selectforeground",
                                                        ("focus",))
+        kwargs["background"] = self.style.lookup("TSpinbox",
+                                                 "fieldbackground",
+                                                 default='white')
+        kwargs["foreground"] = self.style.lookup("TSpinbox",
+                                                 "foreground")
+        kwargs["buttonbackground"] = self.style.lookup("TSpinbox",
+                                                       "background")
         tk.Spinbox.__init__(self, self.frame, **kwargs)
         tk.Spinbox.pack(self, padx=1, pady=1)
         self.frame.spinbox = self

--- a/ttkwidgets/color/spinbox.py
+++ b/ttkwidgets/color/spinbox.py
@@ -97,26 +97,23 @@ class Spinbox(tk.Spinbox):
         self.place_info = self.frame.place_info
         self.place_slaves = self.frame.place_slaves
 
-        self.bind_class("ttkSpinbox", "<FocusIn>", self.focusin, True)
-        self.bind_class("ttkSpinbox", "<FocusOut>", self.focusout, True)
+        self.bind('<1>', lambda e: self.focus_set())
+        self.frame.bind("<FocusIn>", self.focusin)
+        self.frame.bind("<FocusOut>", self.focusout)
 
-    @staticmethod
-    def focusout(event):
+    def focusout(self, event):
         """Change style on focus out events."""
-        w = event.widget.spinbox
-        bc = w.style.lookup("TEntry", "bordercolor", ("!focus",))
-        dc = w.style.lookup("TEntry", "darkcolor", ("!focus",))
-        lc = w.style.lookup("TEntry", "lightcolor", ("!focus",))
-        w.style.configure("%s.spinbox.TFrame" % event.widget, bordercolor=bc,
-                          darkcolor=dc, lightcolor=lc)
+        bc = self.style.lookup("TEntry", "bordercolor", ("!focus",))
+        dc = self.style.lookup("TEntry", "darkcolor", ("!focus",))
+        lc = self.style.lookup("TEntry", "lightcolor", ("!focus",))
+        self.style.configure("%s.spinbox.TFrame" % self.frame, bordercolor=bc,
+                             darkcolor=dc, lightcolor=lc)
 
-    @staticmethod
-    def focusin(event):
+    def focusin(self, event):
         """Change style on focus in events."""
-        w = event.widget.spinbox
-        w.old_value = w.get()
-        bc = w.style.lookup("TEntry", "bordercolor", ("focus",))
-        dc = w.style.lookup("TEntry", "darkcolor", ("focus",))
-        lc = w.style.lookup("TEntry", "lightcolor", ("focus",))
-        w.style.configure("%s.spinbox.TFrame" % event.widget, bordercolor=bc,
-                          darkcolor=dc, lightcolor=lc)
+        self.old_value = self.get()
+        bc = self.style.lookup("TEntry", "bordercolor", ("focus",))
+        dc = self.style.lookup("TEntry", "darkcolor", ("focus",))
+        lc = self.style.lookup("TEntry", "lightcolor", ("focus",))
+        self.style.configure("%s.spinbox.TFrame" % self.frame, bordercolor=bc,
+                             darkcolor=dc, lightcolor=lc)


### PR DESCRIPTION
I have made some small improvements to the `color` submodule:
 - Catch the `ValueError` raised by `locale.getdefaultlocale()` when the default locale of the system is not formatted as python expects it (https://bugs.python.org/issue18378, will be fixed in next python release)
 - Bind `Ctrl+A` to select all the content of the entry or spinbox
 - Initially put insert cursor in the HTML color field
 - Improve the theme compliance of the spinboxes
 - Fix multiple bindings of the spinboxes to `<FocusIn>`/`<FocusOut>`