### PR TITLE
Run tests for python 3.x in Linux (travis CI)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 language: python
 required: sudo
 python:
-    "2.7"
-virtualenv:
-    system_site_packages: true
+  - "2.7"
+  - "3.5"
+  - "3.6"
+  - "3.7"
 before_install:
   - "export DISPLAY=:99.0"
   - sudo systemctl start xvfb
   - sleep 3
 install:
-  - sudo apt-get install python-tk
+  - sudo apt-get install python-tk python3-tk
   - python -m pip install nose coverage codecov mock pynput
 script:
   - python -m pip install .


### PR DESCRIPTION
I think it would be a good idea to run tests for Python 3.x as well as Python 2 in Linux using Travis CI.

I have removed the option `system_site_packages: true` which was restricting us to the use of python versions installed on the system by the package manager and added tests for Python 3.5, 3.6 and 3.7.