### PR TITLE
Small improvements of font widgets

### DIFF
--- a/ttkwidgets/font/familydropdown.py
+++ b/ttkwidgets/font/familydropdown.py
@@ -36,6 +36,7 @@ class FontFamilyDropdown(AutocompleteCombobox):
         self.__callback = callback
         AutocompleteCombobox.__init__(self, master, textvariable=self._font, completevalues=font_families, **kwargs)
         self.bind("<<ComboboxSelected>>", self._on_select)
+        self.bind("<Return>", self._on_select)
 
     def _on_select(self, *args):
         """

--- a/ttkwidgets/font/familydropdown.py
+++ b/ttkwidgets/font/familydropdown.py
@@ -23,14 +23,14 @@ class FontFamilyDropdown(AutocompleteCombobox):
     def __init__(self, master=None, callback=None, **kwargs):
         """
         Create a FontFamilyDropdown.
-        
+
         :param master: master widget
         :type master: widget
         :param callback: callable object with single argument: font family name
         :type callback: function
         :param kwargs: keyword arguments passed on to the :class:`~ttkwidgets.autocomplete.AutocompleteCombobox` initializer
         """
-        font_families = sorted([item for item in font.families()])
+        font_families = sorted(set(font.families()))
         self._fonts = font_families
         self._font = tk.StringVar(master)
         self.__callback = callback
@@ -40,7 +40,7 @@ class FontFamilyDropdown(AutocompleteCombobox):
     def _on_select(self, *args):
         """
         Function bound to event of selection in the Combobox, calls callback if callable
-        
+
         :param args: Tkinter event
         """
         if callable(self.__callback):
@@ -50,7 +50,7 @@ class FontFamilyDropdown(AutocompleteCombobox):
     def selection(self):
         """
         Selection property.
-        
+
         :return: None if no font is selected and font family name if one is selected.
         :rtype: None or str
         """

--- a/ttkwidgets/font/familylistbox.py
+++ b/ttkwidgets/font/familylistbox.py
@@ -60,7 +60,6 @@ class FontFamilyListbox(ScrolledListbox):
         :rtype: None or str
         """
         selection = self.listbox.curselection()
-        print(selection)
         if len(selection) is 0:
             return None
         return self.font_indexes[self.listbox.curselection()[0]]

--- a/ttkwidgets/font/familylistbox.py
+++ b/ttkwidgets/font/familylistbox.py
@@ -24,7 +24,7 @@ class FontFamilyListbox(ScrolledListbox):
     def __init__(self, master=None, callback=None, **kwargs):
         """
         Create a FontFamilyListbox.
-        
+
         :param master: master widget
         :type master: widget
         :param callback: callable object with one argument: the font family name
@@ -33,7 +33,7 @@ class FontFamilyListbox(ScrolledListbox):
         """
         ScrolledListbox.__init__(self, master, compound=tk.RIGHT, **kwargs)
         self._callback = callback
-        font_names = sorted(font.families())
+        font_names = sorted(set(font.families()))
         index = 0
         self.font_indexes = {}
         for name in font_names:
@@ -45,7 +45,7 @@ class FontFamilyListbox(ScrolledListbox):
     def _on_click(self, *args):
         """
         Function bound to double click on Listbox that calls the callback if a valid callback object is passed
-        
+
         :param args: Tkinter event
         """
         if callable(self._callback):
@@ -55,7 +55,7 @@ class FontFamilyListbox(ScrolledListbox):
     def selection(self):
         """
                 Selection property.
-        
+
         :return: None if no font is selected and font family name if one is selected.
         :rtype: None or str
         """

--- a/ttkwidgets/font/familylistbox.py
+++ b/ttkwidgets/font/familylistbox.py
@@ -40,7 +40,7 @@ class FontFamilyListbox(ScrolledListbox):
             self.listbox.insert(index, name)
             self.font_indexes[index] = name
             index += 1
-        self.listbox.bind("<Button-1>", self._on_click)
+        self.listbox.bind("<<ListboxSelect>>", self._on_click)
 
     def _on_click(self, *args):
         """
@@ -60,6 +60,7 @@ class FontFamilyListbox(ScrolledListbox):
         :rtype: None or str
         """
         selection = self.listbox.curselection()
+        print(selection)
         if len(selection) is 0:
             return None
         return self.font_indexes[self.listbox.curselection()[0]]

--- a/ttkwidgets/font/selectframe.py
+++ b/ttkwidgets/font/selectframe.py
@@ -57,7 +57,7 @@ class FontSelectFrame(ttk.Frame):
     def _on_family(self, name):
         """
         Callback if family is changed.
-        
+
         :param name: font family name
         """
         self._family = name
@@ -66,7 +66,7 @@ class FontSelectFrame(ttk.Frame):
     def _on_size(self, size):
         """
         Callback if size is changed.
-        
+
         :param size: font size int
         """
         self._size = size
@@ -75,7 +75,7 @@ class FontSelectFrame(ttk.Frame):
     def _on_properties(self, properties):
         """
         Callback if properties are changed
-        
+
         :param properties: tuple (bold, italic, underline, overstrike)
         """
         self._bold, self._italic, self._underline, self._overstrike = properties
@@ -89,7 +89,7 @@ class FontSelectFrame(ttk.Frame):
     def __generate_font_tuple(self):
         """
         Generate a font tuple for tkinter widgets based on the user's entries.
-        
+
         :return: font tuple (family_name, size, *options)
         """
         if not self._family:
@@ -109,12 +109,12 @@ class FontSelectFrame(ttk.Frame):
     def font(self):
         """
         Font property.
-        
+
         :return: a :class:`~font.Font` object if family is set, else None
         :rtype: :class:`~font.Font` or None
         """
         if not self._family:
-            return None
+            return None, None
         font_obj = font.Font(family=self._family, size=self._size,
                              weight=font.BOLD if self._bold else font.NORMAL,
                              slant=font.ITALIC if self._italic else font.ROMAN,

--- a/ttkwidgets/font/sizedropdown.py
+++ b/ttkwidgets/font/sizedropdown.py
@@ -32,13 +32,14 @@ class FontSizeDropdown(AutocompleteCombobox):
         values = [str(value) for value in int_values]
         AutocompleteCombobox.__init__(self, master, completevalues=values, **kwargs)
         self.bind("<<ComboboxSelected>>", self._on_click)
+        self.bind("<Return>", self._on_click)
         self.__callback = callback
         self.insert(0, "12")
 
     def _on_click(self, event):
         """
         Function bound to event of selection in the Combobox, calls callback if callable
-        
+
         :param event: Tkinter event
         """
         if callable(self.__callback):


### PR DESCRIPTION
- Remove duplicate font names from family list (in `FontFamilyDropdown` and `FontFamilyListbox`).
  Tkinter lists some fonts on my computer several times, so I got rid of the duplicates.

- Fix lag between font selection and callback in `FontFamilyListbox`.
  In the `FontFamilyListbox`, the `_on_click()` callback was executed on the previously selected font. This happens because it is triggered by the `<Button-1>` event that occurs before the class `<Button-1>` event (i.e. the selection of the listbox item). I replaced the binding to  `<Button-1>` by a binding to `<<ListboxSelect>>`, this way, the correct item is used in `_on_click()`. Moreover, `_on_click()` is also executed when browsing the listbox with the arrow keys. If you don't want this behavior (though I find it normal that the font overview is updated when navigating with arrow keys), you can use a binding to  `<ButtonRelease-1>` instead.
- For consistency, make  `FontSelectFrame.font` always return a tuple, i.e. when no family is selected, `(None, None)` is returned instead of just `None`. The former behavior caused an error in the example for the `FontSelectFrame`.

- Bind `<Return>` to the callback of `FontSizeDropdown` and `FontFamilyDropdown`: this way, in the example for the `FontSelectFrame`, if I type directly in the combobox and hit enter, then the preview is updated.